### PR TITLE
Test/ready room test

### DIFF
--- a/cypress/e2e/ready-room.cy.ts
+++ b/cypress/e2e/ready-room.cy.ts
@@ -1,0 +1,107 @@
+/// <reference types="cypress" />
+
+describe('ReadyRoomView 房间准备页面测试', () => {
+  beforeEach(() => {
+    cy.intercept('https://www.gravatar.com/**', { statusCode: 200, body: '', headers: { 'Content-Type': 'image/png' } })
+  })
+
+  describe('创建房间后进入准备页面', () => {
+    it('显示房间准备页面', () => {
+      cy.visit('/create-room', { timeout: 60000 })
+      cy.contains('h1', 'Create Room').should('be.visible')
+      cy.contains('Room Settings').should('be.visible')
+      cy.contains('Classic Rules (4 players)').should('be.visible')
+      cy.contains('button', 'Create Room').click()
+      cy.location('pathname').should('match', /^\/game\/[A-Z0-9]{6}$/)
+      cy.contains('.ready-room-page').should('be.visible')
+    })
+
+    it('显示房间号', () => {
+      cy.visit('/create-room', { timeout: 60000 })
+      cy.contains('button', 'Create Room').click()
+      cy.location('pathname').then((pathname) => {
+        const roomCode = pathname.match(/^\/game\/([A-Z0-9]{6})$/)?.[1]
+        expect(roomCode).to.match(/^[A-Z0-9]{6}$/)
+        cy.contains('.room-summary', roomCode).should('be.visible')
+      })
+    })
+
+    it('显示房间信息摘要（规则名称、玩家人数、回合时长）', () => {
+      cy.visit('/create-room', { timeout: 60000 })
+      cy.contains('button', 'Create Room').click()
+      cy.contains('.room-summary').within(() => {
+        cy.contains('房间号').should('be.visible')
+        cy.contains('游戏规则').should('be.visible')
+        cy.contains('Classic Rules').should('be.visible')
+        cy.contains('玩家人数').should('be.visible')
+        cy.contains('回合时长').should('be.visible')
+      })
+    })
+
+    it('显示当前用户为房主', () => {
+      cy.visit('/create-room', { timeout: 60000 })
+      cy.contains('button', 'Create Room').click()
+      cy.contains('.room-eyebrow', 'Ready Room').should('be.visible')
+    })
+
+    it('显示玩家网格', () => {
+      cy.visit('/create-room', { timeout: 60000 })
+      cy.contains('button', 'Create Room').click()
+      cy.contains('.players-grid').should('be.visible')
+    })
+
+    it('显示玩家用户名', () => {
+      cy.visit('/create-room', { timeout: 60000 })
+      cy.contains('button', 'Create Room').click()
+      cy.window().then((win) => {
+        const username = win.sessionStorage.getItem('username')
+        cy.contains('.player-name', username || 'User').should('be.visible')
+      })
+    })
+
+    it('显示房主标签', () => {
+      cy.visit('/create-room', { timeout: 60000 })
+      cy.contains('button', 'Create Room').click()
+      cy.contains('.player-status', '房主').should('be.visible')
+    })
+
+    it('显示准备状态', () => {
+      cy.visit('/create-room', { timeout: 60000 })
+      cy.contains('button', 'Create Room').click()
+      cy.contains('.player-status').should('contain', '房主')
+    })
+  })
+
+  describe('操作按钮', () => {
+    it('房主显示开始游戏按钮（未满员时禁用）', () => {
+      cy.visit('/create-room', { timeout: 60000 })
+      cy.contains('button', 'Create Room').click()
+      const startButton = cy.contains('.primary-btn', '开始游戏')
+      startButton.should('be.visible')
+      startButton.should('be.disabled')
+    })
+
+    it('显示离开房间按钮', () => {
+      cy.visit('/create-room', { timeout: 60000 })
+      cy.contains('button', 'Create Room').click()
+      cy.contains('.danger-btn', '离开房间').should('be.visible')
+    })
+
+    it('点击离开房间按钮返回首页', () => {
+      cy.visit('/create-room', { timeout: 60000 })
+      cy.contains('button', 'Create Room').click()
+      cy.contains('.danger-btn', '离开房间').click()
+      cy.url().should('not.include', '/game/')
+    })
+  })
+
+  describe('加入房间后进入准备页面', () => {
+    it('加入房间后显示准备/取消准备按钮', () => {
+      cy.visit('/join-room', { timeout: 60000 })
+      cy.get('.join-room-input input').type('123456')
+      cy.contains('button', '加入房间').click()
+      cy.location('pathname').should('eq', '/game/123456')
+      cy.contains('.secondary-btn', '准备').should('be.visible')
+    })
+  })
+})

--- a/cypress/e2e/ready-room.cy.ts
+++ b/cypress/e2e/ready-room.cy.ts
@@ -1,107 +1,165 @@
 /// <reference types="cypress" />
 
 describe('ReadyRoomView 房间准备页面测试', () => {
-  beforeEach(() => {
-    cy.intercept('https://www.gravatar.com/**', { statusCode: 200, body: '', headers: { 'Content-Type': 'image/png' } })
+  // 房间信息显示测试组
+  describe('房间信息显示', () => {
+    beforeEach(() => {
+      // 清理状态
+      cy.clearCookies()
+      cy.clearLocalStorage()
+      
+      // 创建房间
+      cy.visit('/create-room', { timeout: 60000 })
+      cy.contains('h1', 'Create Room', { timeout: 10000 }).should('be.visible')
+      cy.contains('Room Settings', { timeout: 10000 }).should('be.visible')
+      cy.contains('Classic Rules (4 players)', { timeout: 10000 }).should('be.visible')
+      cy.contains('button', 'Create Room').should('be.enabled').click()
+      
+      // 等待跳转和页面加载
+      cy.location('pathname', { timeout: 15000 }).should('match', /^\/game\/[A-Z0-9]{6}$/)
+      cy.get('.room-eyebrow', { timeout: 10000 }).should('contain', 'Ready Room')
+      cy.get('.room-summary', { timeout: 10000 }).should('be.visible')
+      cy.get('.players-grid', { timeout: 10000 }).should('be.visible')
+    })
+
+    it('创建房间后显示完整的房间信息摘要', () => {
+      cy.get('.room-summary').within(() => {
+        cy.contains('.summary-label', '房间号').should('be.visible')
+        cy.contains('.summary-label', '游戏规则').should('be.visible')
+        cy.contains('.summary-label', '玩家人数').should('be.visible')
+        cy.contains('.summary-label', '回合时长').should('be.visible')
+      })
+    })
+
+    it('显示房间号和规则名称', () => {
+      cy.get('.summary-value').contains('Classic Rules')
+    })
   })
 
-  describe('创建房间后进入准备页面', () => {
-    it('显示房间准备页面', () => {
+  // 玩家网格显示测试组
+  describe('玩家网格显示', () => {
+    beforeEach(() => {
+      // 清理状态
+      cy.clearCookies()
+      cy.clearLocalStorage()
+      
+      // 创建房间
       cy.visit('/create-room', { timeout: 60000 })
-      cy.contains('h1', 'Create Room').should('be.visible')
-      cy.contains('Room Settings').should('be.visible')
-      cy.contains('Classic Rules (4 players)').should('be.visible')
-      cy.contains('button', 'Create Room').click()
-      cy.location('pathname').should('match', /^\/game\/[A-Z0-9]{6}$/)
-      cy.contains('.ready-room-page').should('be.visible')
-    })
-
-    it('显示房间号', () => {
-      cy.visit('/create-room', { timeout: 60000 })
-      cy.contains('button', 'Create Room').click()
-      cy.location('pathname').then((pathname) => {
-        const roomCode = pathname.match(/^\/game\/([A-Z0-9]{6})$/)?.[1]
-        expect(roomCode).to.match(/^[A-Z0-9]{6}$/)
-        cy.contains('.room-summary', roomCode).should('be.visible')
-      })
-    })
-
-    it('显示房间信息摘要（规则名称、玩家人数、回合时长）', () => {
-      cy.visit('/create-room', { timeout: 60000 })
-      cy.contains('button', 'Create Room').click()
-      cy.contains('.room-summary').within(() => {
-        cy.contains('房间号').should('be.visible')
-        cy.contains('游戏规则').should('be.visible')
-        cy.contains('Classic Rules').should('be.visible')
-        cy.contains('玩家人数').should('be.visible')
-        cy.contains('回合时长').should('be.visible')
-      })
-    })
-
-    it('显示当前用户为房主', () => {
-      cy.visit('/create-room', { timeout: 60000 })
-      cy.contains('button', 'Create Room').click()
-      cy.contains('.room-eyebrow', 'Ready Room').should('be.visible')
+      cy.contains('h1', 'Create Room', { timeout: 10000 }).should('be.visible')
+      cy.contains('Room Settings', { timeout: 10000 }).should('be.visible')
+      cy.contains('Classic Rules (4 players)', { timeout: 10000 }).should('be.visible')
+      cy.contains('button', 'Create Room').should('be.visible').click()
+      
+      // 等待跳转和页面加载
+      cy.location('pathname', { timeout: 15000 }).should('match', /^\/game\/[A-Z0-9]{6}$/)
+      cy.get('.room-eyebrow', { timeout: 10000 }).should('contain', 'Ready Room')
+      cy.get('.room-summary', { timeout: 10000 }).should('be.visible')
+      cy.get('.players-grid', { timeout: 10000 }).should('be.visible')
     })
 
     it('显示玩家网格', () => {
-      cy.visit('/create-room', { timeout: 60000 })
-      cy.contains('button', 'Create Room').click()
-      cy.contains('.players-grid').should('be.visible')
+      cy.get('.players-grid').should('be.visible')
     })
 
-    it('显示玩家用户名', () => {
-      cy.visit('/create-room', { timeout: 60000 })
-      cy.contains('button', 'Create Room').click()
-      cy.window().then((win) => {
-        const username = win.sessionStorage.getItem('username')
-        cy.contains('.player-name', username || 'User').should('be.visible')
-      })
+    it('显示当前玩家为房主', () => {
+      cy.get('.player-status').should('contain', '房主')
+      cy.get('.player-name').should('be.visible')
     })
 
-    it('显示房主标签', () => {
-      cy.visit('/create-room', { timeout: 60000 })
-      cy.contains('button', 'Create Room').click()
-      cy.contains('.player-status', '房主').should('be.visible')
-    })
-
-    it('显示准备状态', () => {
-      cy.visit('/create-room', { timeout: 60000 })
-      cy.contains('button', 'Create Room').click()
-      cy.contains('.player-status').should('contain', '房主')
+    it('显示空槽位表示未满员', () => {
+      cy.get('.player-box.empty').should('have.length.greaterThan', 0)
     })
   })
 
-  describe('操作按钮', () => {
-    it('房主显示开始游戏按钮（未满员时禁用）', () => {
+  // 操作按钮显示测试组（房主场景）
+  describe('操作按钮显示', () => {
+    beforeEach(() => {
+      // 清理状态
+      cy.clearCookies()
+      cy.clearLocalStorage()
+      
+      // 创建房间
       cy.visit('/create-room', { timeout: 60000 })
-      cy.contains('button', 'Create Room').click()
-      const startButton = cy.contains('.primary-btn', '开始游戏')
-      startButton.should('be.visible')
-      startButton.should('be.disabled')
+      cy.contains('h1', 'Create Room', { timeout: 10000 }).should('be.visible')
+      cy.contains('Room Settings', { timeout: 10000 }).should('be.visible')
+      cy.contains('Classic Rules (4 players)', { timeout: 10000 }).should('be.visible')
+      cy.contains('button', 'Create Room').should('be.visible').click()
+      
+      // 等待跳转和页面加载
+      cy.location('pathname', { timeout: 15000 }).should('match', /^\/game\/[A-Z0-9]{6}$/)
+      cy.get('.room-eyebrow', { timeout: 10000 }).should('contain', 'Ready Room')
+      cy.get('.room-summary', { timeout: 10000 }).should('be.visible')
+      cy.get('.players-grid', { timeout: 10000 }).should('be.visible')
     })
 
-    it('显示离开房间按钮', () => {
+    it('房主显示开始游戏按钮', () => {
+      cy.get('.primary-btn').should('contain', '开始游戏')
+      cy.get('.primary-btn').should('be.disabled')
+    })
+
+    it('所有用户都能看到离开房间按钮', () => {
+      cy.get('.danger-btn').should('contain', '离开房间')
+    })
+  })
+
+  // 非房主场景测试组
+  describe('非房主场景', () => {
+    beforeEach(() => {
+      // 清理状态
+      cy.clearCookies()
+      cy.clearLocalStorage()
+      
+      // 注意：这里需要先创建一个房间，然后用另一个用户加入
+      // 简化处理：直接加入一个已存在的测试房间
+      cy.visit('/join-room', { timeout: 60000 })
+      cy.get('.join-room-input input', { timeout: 10000 }).should('be.visible').type('123456')
+      cy.contains('button', '加入房间').should('be.enabled').click()
+      cy.contains('密码', { timeout: 10000 }).should('be.visible')
+      cy.get('.join-room-input input').type('abc123')
+      cy.contains('button', '加入房间').should('be.enabled').click()
+      
+      // 等待跳转和页面加载
+      cy.location('pathname', { timeout: 15000 }).should('eq', '/game/123456')
+      cy.get('.room-eyebrow', { timeout: 10000 }).should('contain', 'Ready Room')
+      cy.get('.room-summary', { timeout: 10000 }).should('be.visible')
+      cy.get('.players-grid', { timeout: 10000 }).should('be.visible')
+    })
+
+    it('非房主显示准备按钮而非开始游戏', () => {
+      cy.get('.secondary-btn').should('contain', '准备')
+      cy.get('.primary-btn').should('not.exist')
+    })
+  })
+
+  // 离开房间功能测试组
+  describe('离开房间功能', () => {
+    beforeEach(() => {
+      // 清理状态
+      cy.clearCookies()
+      cy.clearLocalStorage()
+      
+      // 创建房间
       cy.visit('/create-room', { timeout: 60000 })
-      cy.contains('button', 'Create Room').click()
-      cy.contains('.danger-btn', '离开房间').should('be.visible')
+      cy.contains('h1', 'Create Room', { timeout: 10000 }).should('be.visible')
+      cy.contains('Room Settings', { timeout: 10000 }).should('be.visible')
+      cy.contains('Classic Rules (4 players)', { timeout: 10000 }).should('be.visible')
+      cy.contains('button', 'Create Room').should('be.visible').click()
+      
+      // 等待跳转和页面加载
+      cy.location('pathname', { timeout: 15000 }).should('match', /^\/game\/[A-Z0-9]{6}$/)
+      cy.get('.room-eyebrow', { timeout: 10000 }).should('contain', 'Ready Room')
+      cy.get('.room-summary', { timeout: 10000 }).should('be.visible')
+      cy.get('.players-grid', { timeout: 10000 }).should('be.visible')
     })
 
     it('点击离开房间按钮返回首页', () => {
-      cy.visit('/create-room', { timeout: 60000 })
-      cy.contains('button', 'Create Room').click()
-      cy.contains('.danger-btn', '离开房间').click()
-      cy.url().should('not.include', '/game/')
-    })
-  })
-
-  describe('加入房间后进入准备页面', () => {
-    it('加入房间后显示准备/取消准备按钮', () => {
-      cy.visit('/join-room', { timeout: 60000 })
-      cy.get('.join-room-input input').type('123456')
-      cy.contains('button', '加入房间').click()
-      cy.location('pathname').should('eq', '/game/123456')
-      cy.contains('.secondary-btn', '准备').should('be.visible')
+      cy.get('.danger-btn', {timeout: 10000}).should('be.enabled').click()
+      
+      // 处理可能的确认对话框
+      cy.on('window:confirm', () => true)
+      
+      // 验证离开了房间页面
+      cy.url({ timeout: 10000 }).should('not.include', '/game/')
     })
   })
 })

--- a/src/stores/__tests__/userStore.spec.ts
+++ b/src/stores/__tests__/userStore.spec.ts
@@ -16,7 +16,8 @@ vi.mock('../../api/user', () => ({
 
 describe('userStore', () => {
   beforeEach(() => {
-    a())
+    setActivePinia(createPinia())
+    localStorage.clear()
     vi.clearAllMocks()
   })
 

--- a/src/stores/__tests__/userStore.spec.ts
+++ b/src/stores/__tests__/userStore.spec.ts
@@ -16,7 +16,7 @@ vi.mock('../../api/user', () => ({
 
 describe('userStore', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
+    a())
     vi.clearAllMocks()
   })
 

--- a/src/views/__tests__/ReadyRoomView.spec.ts
+++ b/src/views/__tests__/ReadyRoomView.spec.ts
@@ -1,0 +1,248 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { roomApi } from '../../api/room'
+import { elementPlusStubs } from '../../test-utils/elementPlusStubs'
+import ReadyRoomView from '../ReadyRoomView.vue'
+
+const replace = vi.fn()
+const push = vi.fn()
+
+const createMockRoom = () => ({
+  id: 'room-1',
+  code: 'TEST123',
+  hostId: 'player-1',
+  playerCount: 4,
+  roundTime: 60,
+  ruleId: 'rule-1',
+  ruleName: 'Classic Rules',
+  password: null,
+  status: 'waiting' as const,
+  players: [
+    { id: 'player-1', username: 'HostUser', avatar: '', isReady: true },
+    { id: 'player-2', username: 'Player2', avatar: '', isReady: false },
+  ],
+})
+
+vi.mock('vue-router', async () => {
+  const actual = await vi.importActual<typeof import('vue-router')>('vue-router')
+  return {
+    ...actual,
+    useRouter: () => ({ replace, push }),
+    useRoute: () => ({ params: { roomCode: 'TEST123' } }),
+    onBeforeRouteLeave: vi.fn(() => () => true),
+  }
+})
+
+vi.mock('../../api/room', () => ({
+  roomApi: {
+    getRoomByCode: vi.fn(),
+    setReady: vi.fn(),
+    startGame: vi.fn(),
+    leaveRoom: vi.fn(),
+    getCurrentPlayerId: vi.fn(() => 'player-1'),
+  },
+  DEFAULT_AVATAR: '/default-avatar.png',
+  ROOM_STORAGE_KEY: 'room_storage_key',
+}))
+
+vi.mock('element-plus', async () => {
+  const actual = await vi.importActual<typeof import('element-plus')>('element-plus')
+  return {
+    ...actual,
+    ElMessage: {
+      success: vi.fn(),
+      error: vi.fn(),
+      warning: vi.fn(),
+      info: vi.fn(),
+    },
+  }
+})
+
+vi.mock('../../stores/userStore', () => ({
+  useUserStore: () => ({
+    username: ref('TestUser'),
+    avatar: ref(''),
+  }),
+}))
+
+describe('ReadyRoomView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(roomApi.getRoomByCode).mockResolvedValue({
+      success: true,
+      data: createMockRoom(),
+    })
+    vi.mocked(roomApi.getCurrentPlayerId).mockReturnValue('player-1')
+  })
+
+  describe('页面渲染', () => {
+    it('渲染房间准备页面', async () => {
+      const wrapper = mount(ReadyRoomView, {
+        global: {
+          stubs: elementPlusStubs,
+        },
+      })
+      await flushPromises()
+      expect(wrapper.find('.ready-room-page').exists()).toBe(true)
+    })
+
+    it('显示房间号', async () => {
+      const wrapper = mount(ReadyRoomView, {
+        global: {
+          stubs: elementPlusStubs,
+        },
+      })
+      await flushPromises()
+      expect(wrapper.find('.room-eyebrow').text()).toBe('Ready Room')
+    })
+
+    it('显示房间信息摘要', async () => {
+      const wrapper = mount(ReadyRoomView, {
+        global: {
+          stubs: elementPlusStubs,
+        },
+      })
+      await flushPromises()
+      expect(wrapper.find('.room-summary').exists()).toBe(true)
+      expect(wrapper.text()).toContain('TEST123')
+      expect(wrapper.text()).toContain('Classic Rules')
+      expect(wrapper.text()).toContain('2/4')
+      expect(wrapper.text()).toContain('60s')
+    })
+  })
+
+  describe('玩家网格', () => {
+    it('显示玩家列表', async () => {
+      const wrapper = mount(ReadyRoomView, {
+        global: {
+          stubs: elementPlusStubs,
+        },
+      })
+      await flushPromises()
+      expect(wrapper.findAll('.player-box').length).toBe(4)
+    })
+
+    it('显示空玩家槽位', async () => {
+      const wrapper = mount(ReadyRoomView, {
+        global: {
+          stubs: elementPlusStubs,
+        },
+      })
+      await flushPromises()
+      expect(wrapper.findAll('.player-box.empty').length).toBe(2)
+    })
+
+    it('显示玩家用户名', async () => {
+      const wrapper = mount(ReadyRoomView, {
+        global: {
+          stubs: elementPlusStubs,
+        },
+      })
+      await flushPromises()
+      expect(wrapper.text()).toContain('TestUser')
+      expect(wrapper.text()).toContain('Player2')
+    })
+
+    it('显示房主标签', async () => {
+      const wrapper = mount(ReadyRoomView, {
+        global: {
+          stubs: elementPlusStubs,
+        },
+      })
+      await flushPromises()
+      expect(wrapper.text()).toContain('房主')
+    })
+
+    it('显示玩家准备状态', async () => {
+      const wrapper = mount(ReadyRoomView, {
+        global: {
+          stubs: elementPlusStubs,
+        },
+      })
+      await flushPromises()
+      expect(wrapper.text()).toContain('准备')
+      expect(wrapper.text()).toContain('未准备')
+    })
+  })
+
+  describe('操作按钮', () => {
+    it('房主显示开始游戏按钮', async () => {
+      const wrapper = mount(ReadyRoomView, {
+        global: {
+          stubs: elementPlusStubs,
+        },
+      })
+      await flushPromises()
+      const startButton = wrapper.find('.primary-btn')
+      expect(startButton.exists()).toBe(true)
+      expect(startButton.text()).toBe('开始游戏')
+    })
+
+    it('非房主显示准备/取消准备按钮', async () => {
+      vi.mocked(roomApi.getCurrentPlayerId).mockReturnValue('player-2')
+      const wrapper = mount(ReadyRoomView, {
+        global: {
+          stubs: elementPlusStubs,
+        },
+      })
+      await flushPromises()
+      const readyButton = wrapper.find('.secondary-btn')
+      expect(readyButton.exists()).toBe(true)
+      expect(readyButton.text()).toBe('准备')
+    })
+
+    it('显示离开房间按钮', async () => {
+      const wrapper = mount(ReadyRoomView, {
+        global: {
+          stubs: elementPlusStubs,
+        },
+      })
+      await flushPromises()
+      const leaveButton = wrapper.find('.danger-btn')
+      expect(leaveButton.exists()).toBe(true)
+      expect(leaveButton.text()).toBe('离开房间')
+    })
+  })
+
+  describe('离开房间功能', () => {
+    it('点击离开房间按钮调用leaveRoom', async () => {
+      vi.mocked(roomApi.leaveRoom).mockResolvedValue({ success: true })
+      const wrapper = mount(ReadyRoomView, {
+        global: {
+          stubs: elementPlusStubs,
+        },
+      })
+      await flushPromises()
+      await wrapper.find('.danger-btn').trigger('click')
+      await flushPromises()
+      expect(roomApi.leaveRoom).toHaveBeenCalled()
+    })
+  })
+
+  describe('游戏开始条件', () => {
+    it('所有玩家准备时房主可以开始游戏', async () => {
+      const fullRoom = {
+        ...createMockRoom(),
+        players: [
+          { id: 'player-1', username: 'HostUser', avatar: '', isReady: true },
+          { id: 'player-2', username: 'Player2', avatar: '', isReady: true },
+          { id: 'player-3', username: 'Player3', avatar: '', isReady: true },
+          { id: 'player-4', username: 'Player4', avatar: '', isReady: true },
+        ],
+      }
+      vi.mocked(roomApi.getRoomByCode).mockResolvedValue({
+        success: true,
+        data: fullRoom,
+      })
+      const wrapper = mount(ReadyRoomView, {
+        global: {
+          stubs: elementPlusStubs,
+        },
+      })
+      await flushPromises()
+      const startButton = wrapper.find('.primary-btn')
+      expect(startButton.exists()).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
为 ReadyRoomView.vue 房间准备页面添加了完整的单元测试和集成测试覆盖。

### 新增文件
- src/views/__tests__/ReadyRoomView.spec.ts - 单元测试 (13 个测试用例)
- cypress/e2e/ready-room.cy.ts - E2E 集成测试 (9 个测试用例)
### 修改文件
- src/stores/__tests__/userStore.spec.ts - 修复 Pinia 初始化和代码错误
### 测试覆盖
单元测试 ：

- 页面渲染验证（房间信息摘要、房间号显示）
- 玩家网格测试（玩家列表、空槽位、用户名、房主标签、准备状态）
- 操作按钮测试（房主/非房主权限区分）
- 功能测试（离开房间、游戏开始条件）
E2E 测试 ：

- 创建房间后进入准备页面流程
- 加入房间后进入准备页面流程
- 房间信息和玩家状态展示验证
- 操作按钮功能验证