### PR TITLE
feat(user): login form accepts username in addition to email

### DIFF
--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -12,6 +12,7 @@ export interface User {
 }
 
 export interface LoginParams {
+  // accepts either an email (contains '@') or a username; field name kept for backend wire compatibility
   email: string
   password: string
 }

--- a/src/stores/__tests__/userStore.spec.ts
+++ b/src/stores/__tests__/userStore.spec.ts
@@ -78,6 +78,41 @@ describe('userStore', () => {
       expect(result.success).toBe(false)
       expect(store.isLoggedIn).toBe(false)
     })
+
+    it('使用用户名（无 @）也能调用 login，传递给后端的 email 字段保持原值', async () => {
+      vi.mocked(userApi.login).mockResolvedValue({
+        success: true,
+        data: {
+          id: '2',
+          username: 'tjydemo',
+          email: 'tjydemo@example.com',
+          avatar: '',
+        },
+      })
+
+      const store = useUserStore()
+
+      const result = await store.login({
+        email: 'tjydemo',
+        password: 'secret',
+      })
+
+      expect(result.success).toBe(true)
+      expect(store.isLoggedIn).toBe(true)
+      expect(vi.mocked(userApi.login)).toHaveBeenCalledWith({
+        email: 'tjydemo',
+        password: 'secret',
+      })
+    })
+
+    it('空凭据时返回包含"邮箱或用户名"的提示', async () => {
+      const store = useUserStore()
+
+      const result = await store.login({ email: '', password: '' })
+
+      expect(result.success).toBe(false)
+      expect(result.message).toContain('邮箱或用户名')
+    })
   })
 
   describe('注册功能', () => {

--- a/src/stores/userStore.ts
+++ b/src/stores/userStore.ts
@@ -67,7 +67,7 @@ export const useUserStore = defineStore('user', {
       const trimmedPassword = password.trim()
 
       if (!trimmedEmail || !trimmedPassword) {
-        return { success: false, message: '请输入邮箱和密码' }
+        return { success: false, message: '请输入邮箱或用户名以及密码' }
       }
 
       const result = await userApi.login({

--- a/src/views/UserView.vue
+++ b/src/views/UserView.vue
@@ -38,8 +38,8 @@
         <el-tab-pane label="登录" name="login">
           <div class="auth-form">
             <div class="auth-field">
-              <div class="setting-label">邮箱</div>
-              <el-input v-model="loginForm.email" placeholder="example@mail.com" class="setting-input" />
+              <div class="setting-label">邮箱 / 用户名</div>
+              <el-input v-model="loginForm.email" placeholder="邮箱或用户名" class="setting-input" />
             </div>
             <div class="auth-field">
               <div class="setting-label">密码</div>
@@ -192,7 +192,7 @@ async function onLogin() {
   const password = loginForm.password.trim()
 
   if (!emailValue || !password) {
-    ElMessage.error('请输入邮箱和密码')
+    ElMessage.error('请输入邮箱或用户名以及密码')
     return
   }
 


### PR DESCRIPTION
飞书任务板 \`recvk46QbAZ82H\` + \`recvkfRNNoAJCf\`。

## 改动
- \`UserView.vue\` 登录 tab："邮箱" 标签和 placeholder 更新为同时支持邮箱/用户名
- \`userStore.ts\` 空值提示文案与新行为对齐
- \`api/user.ts\` 给 \`LoginParams.email\` 加注释说明语义，结构不变（向后端仍传 \`email\` 字段）
- \`userStore.spec.ts\` 补 2 个用例：用户名登录路径透传、空凭据提示包含"邮箱或用户名"

## 验证
- \`npm run test:unit\` ：88 passed（HomeView 2 个 pre-existing 失败与本 PR 无关，main 上同样失败）
- 浏览器手测：邮箱登录 ✅、用户名登录 ✅、空字段提示文案 ✅
- 与后端 PR BUAA-ISET/WildCard_BackEnd#62 端到端联调通过

## 不在本 PR
- el-input 下划线显示问题：#98 单独跟踪

Closes #99
Closes #100