### PR TITLE
fix(ui): restore underscore glyph in setting-input

### DIFF
--- a/src/views/UserView.vue
+++ b/src/views/UserView.vue
@@ -424,6 +424,19 @@ async function onUpdatePassword() {
   width: 100%;
 }
 
+.setting-input :deep(.el-input__inner) {
+  line-height: 1.6;
+  height: auto;
+  padding-block: 4px;
+  font-family: system-ui, 'Segoe UI', 'PingFang SC', 'Microsoft YaHei', sans-serif;
+  -webkit-text-fill-color: currentColor;
+}
+
+.setting-input :deep(.el-input__inner:-webkit-autofill) {
+  -webkit-box-shadow: 0 0 0 1000px #fff inset;
+  -webkit-text-fill-color: currentColor;
+}
+
 .inline-field {
   display: flex;
   gap: 12px;


### PR DESCRIPTION
## 问题
在 UserView 登录/注册/资料表单中，包含 \`_\` 的输入显示为空白（用户验证用户名 \`tjy_demo\` 时发现）。\`v-model\` 数据正确，仅 UI 显示丢失字形。

## 修复
\`UserView.vue\` 中给 \`.setting-input\` 的 \`:deep(.el-input__inner)\` 增加：
- \`line-height: 1.6\` + \`height: auto\` + \`padding-block: 4px\`：避免 baseline 被父容器截断
- \`font-family\` 显式指定常见可显示 \`_\` 的字体族（含 PingFang SC / Microsoft YaHei 中文兜底）
- \`-webkit-text-fill-color: currentColor\`：抵御某些 WebKit 主题/扩展将其重置为 transparent
- \`:-webkit-autofill\` 兜底，避免浏览器自动填充再次触发同样症状

## 验证
- 浏览器手测：登录页输入 \`tjy_demo\`，\`_\` 字形完整可见
- \`npm run test:unit\` 88 passed（HomeView 2 个 pre-existing 失败与本 PR 无关）

Closes #98