### PR TITLE
feat(user): add email change UI in account settings

### DIFF
--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -29,6 +29,7 @@ export const API_CONFIG = {
             current: '/api/user/current',
             updateUsername: '/api/user/username',
             updatePassword: '/api/user/password',
+            updateEmail: '/api/user/email',
             updateAvatar: '/api/user/avatar',
         },
         room: {

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -29,6 +29,11 @@ export interface UpdatePasswordParams {
   newPassword: string
 }
 
+export interface UpdateEmailParams {
+  newEmail: string
+  verificationCode: string
+}
+
 export interface SendVerificationCodeParams {
   email: string
 }
@@ -440,6 +445,43 @@ export const userApi = {
         account.password = params.newPassword
         saveMockAccountsToStorage()
         return { success: true, message: '密码更新成功' }
+      },
+    })
+  },
+
+  async updateEmail(params: UpdateEmailParams): Promise<ApiResult<User>> {
+    return apiPut(API_CONFIG.endpoints.user.updateEmail, params, {
+      useMock: shouldUseUserMockApi(),
+      mockDelay: 300,
+      mockFn: () => {
+        const newEmail = normalizeEmail(params.newEmail)
+        if (!newEmail || !params.verificationCode.trim()) {
+          return { success: false, message: '请填写新邮箱和验证码' }
+        }
+        if (!currentUser.value) {
+          return { success: false, message: '未登录' }
+        }
+        if (currentUser.value.email === newEmail) {
+          return { success: false, message: '新邮箱与当前邮箱相同' }
+        }
+        const verificationResult = validateVerificationCode(newEmail, params.verificationCode)
+        if (!verificationResult.success) {
+          return verificationResult
+        }
+        if (mockAccounts.has(newEmail)) {
+          return { success: false, message: '该邮箱已被占用' }
+        }
+        const oldEmail = currentUser.value.email
+        const account = mockAccounts.get(oldEmail)
+        if (account) {
+          mockAccounts.delete(oldEmail)
+          account.email = newEmail
+          mockAccounts.set(newEmail, account)
+          saveMockAccountsToStorage()
+        }
+        currentUser.value = { ...currentUser.value, email: newEmail }
+        saveUserToStorage(currentUser.value)
+        return { success: true, data: currentUser.value }
       },
     })
   },

--- a/src/stores/userStore.ts
+++ b/src/stores/userStore.ts
@@ -107,6 +107,25 @@ export const useUserStore = defineStore('user', {
     setUser(user: User | null) {
       this.applyUser(user)
     },
+    async updateEmail({ newEmail, verificationCode }: { newEmail: string; verificationCode: string }) {
+      const trimmedEmail = newEmail.trim()
+      const trimmedCode = verificationCode.trim()
+
+      if (!trimmedEmail || !trimmedCode) {
+        return { success: false, message: '请填写新邮箱和验证码' }
+      }
+
+      const result = await userApi.updateEmail({
+        newEmail: trimmedEmail,
+        verificationCode: trimmedCode,
+      })
+
+      if (result.success && result.data) {
+        this.applyUser(result.data)
+      }
+
+      return result
+    },
     async logout() {
       await userApi.logout()
       this.applyUser(null)

--- a/src/views/UserView.vue
+++ b/src/views/UserView.vue
@@ -25,6 +25,22 @@
           <el-input v-model="passwordForm.confirm" type="password" class="setting-input" />
           <el-button class="user-btn" size="medium" @click="onUpdatePassword">修改密码</el-button>
         </div>
+        <div class="setting-section">
+          <div class="setting-label">新邮箱</div>
+          <el-input v-model="emailForm.newEmail" placeholder="example@mail.com" class="setting-input" />
+          <div class="setting-label">邮箱验证码</div>
+          <div class="inline-field">
+            <el-input v-model="emailForm.verificationCode" class="setting-input compact-input" />
+            <el-button
+              class="send-code-btn"
+              :disabled="emailCountdown > 0"
+              @click="onSendEmailChangeCode"
+            >
+              {{ emailCountdown > 0 ? `${emailCountdown}s` : '发送验证码' }}
+            </el-button>
+          </div>
+          <el-button class="user-btn" size="medium" @click="onUpdateEmail">修改邮箱</el-button>
+        </div>
         <div class="logout-section">
           <el-button type="danger" class="logout-btn" size="medium" @click="onLogout">退出登录</el-button>
         </div>
@@ -135,6 +151,12 @@ const registerForm = reactive({
   password: '',
   confirm: '',
 })
+const emailForm = reactive({
+  newEmail: '',
+  verificationCode: '',
+})
+const emailCountdown = ref(0)
+let emailCountdownTimer: ReturnType<typeof setInterval> | null = null
 
 const isSendingCode = ref(false)
 const verificationCountdown = ref(0)
@@ -320,6 +342,65 @@ async function onUpdatePassword() {
     ElMessage.success(result.message || '密码已更新')
   } else {
     ElMessage.error(result.message || '更新失败')
+  }
+}
+
+function startEmailCountdown() {
+  emailCountdown.value = SEND_CODE_COOLDOWN
+  if (emailCountdownTimer) {
+    clearInterval(emailCountdownTimer)
+  }
+  emailCountdownTimer = setInterval(() => {
+    if (emailCountdown.value <= 1) {
+      emailCountdown.value = 0
+      if (emailCountdownTimer) {
+        clearInterval(emailCountdownTimer)
+        emailCountdownTimer = null
+      }
+    } else {
+      emailCountdown.value -= 1
+    }
+  }, 1000)
+}
+
+async function onSendEmailChangeCode() {
+  const target = emailForm.newEmail.trim()
+  if (!target) {
+    ElMessage.error('请先填写新邮箱')
+    return
+  }
+  const result = await userApi.sendVerificationCode({ email: target })
+  if (result.success) {
+    if (result.debugCode) {
+      emailForm.verificationCode = result.debugCode
+    }
+    startEmailCountdown()
+    ElMessage.success(result.message || '验证码已发送')
+  } else {
+    ElMessage.error(result.message || '发送失败')
+  }
+}
+
+async function onUpdateEmail() {
+  if (!emailForm.newEmail.trim() || !emailForm.verificationCode.trim()) {
+    ElMessage.error('请填写新邮箱和验证码')
+    return
+  }
+  const result = await userStore.updateEmail({
+    newEmail: emailForm.newEmail.trim(),
+    verificationCode: emailForm.verificationCode.trim(),
+  })
+  if (result.success) {
+    emailForm.newEmail = ''
+    emailForm.verificationCode = ''
+    emailCountdown.value = 0
+    if (emailCountdownTimer) {
+      clearInterval(emailCountdownTimer)
+      emailCountdownTimer = null
+    }
+    ElMessage.success(result.message || '邮箱已更新')
+  } else {
+    ElMessage.error(result.message || '邮箱修改失败')
   }
 }
 </script>


### PR DESCRIPTION
飞书任务板 \`recvk46MoZBCow\`。配套后端 PR BUAA-ISET/WildCard_BackEnd#71。

## 改动
- \`api/config.ts\` / \`api/user.ts\` / \`stores/userStore.ts\` / \`views/UserView.vue\`
- 账户页新增"新邮箱 + 验证码 + 发送/提交"区块，独立 60 秒倒计时

## 验证
- \`npm run test:unit\`：88 passed（HomeView 2 个 pre-existing 失败与本 PR 无关）
- \`npm run build\`：类型零错误
- E2E：浏览器登录态用新邮箱调发送 -> 收到 SMTP 邮件 -> 提交修改 -> 顶部邮箱实时更新 -> 重新登录可用

Closes #103