### PR TITLE
feat(user): avatar upload UI

### DIFF
--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,6 +1,6 @@
 import { ref } from 'vue'
 import { apiGet, apiPost, apiPut } from './request'
-import { API_CONFIG, shouldUseMockApi, shouldUseUserMockApi } from './config'
+import { API_CONFIG, getApiUrl, shouldUseMockApi, shouldUseUserMockApi } from './config'
 import { AUTH_TOKEN_STORAGE_KEY, scopedStorageKey, USER_STORAGE_KEY } from '../utils/storageNamespace'
 
 export interface User {
@@ -484,5 +484,64 @@ export const userApi = {
         return { success: true, data: currentUser.value }
       },
     })
+  },
+
+  async uploadAvatar(file: File): Promise<ApiResult<User>> {
+    if (shouldUseUserMockApi()) {
+      if (!currentUser.value) {
+        return { success: false, message: '未登录' }
+      }
+      const reader = new FileReader()
+      const dataUrl: string = await new Promise((resolve, reject) => {
+        reader.onload = () => resolve(String(reader.result || ''))
+        reader.onerror = () => reject(reader.error)
+        reader.readAsDataURL(file)
+      })
+      currentUser.value = { ...currentUser.value, avatar: dataUrl }
+      saveUserToStorage(currentUser.value)
+      return { success: true, data: currentUser.value }
+    }
+
+    const form = new FormData()
+    form.append('file', file)
+    const url = getApiUrl(API_CONFIG.endpoints.user.updateAvatar)
+    const token = (() => {
+      if (typeof window === 'undefined') return ''
+      try {
+        return (
+          window.sessionStorage.getItem(AUTH_TOKEN_STORAGE_KEY) ||
+          window.localStorage.getItem(AUTH_TOKEN_STORAGE_KEY) ||
+          ''
+        )
+      } catch {
+        return ''
+      }
+    })()
+    const headers: Record<string, string> = {}
+    if (token) headers.Authorization = `Bearer ${token}`
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        credentials: 'include',
+        headers,
+        body: form,
+      })
+      const text = await response.text()
+      const result = text ? JSON.parse(text) : {}
+      if (!response.ok) {
+        return {
+          success: false,
+          message:
+            (result as { message?: string }).message ||
+            `Request failed with status ${response.status}`,
+        }
+      }
+      return result as ApiResult<User>
+    } catch (e) {
+      return {
+        success: false,
+        message: e instanceof Error ? e.message : '网络请求失败',
+      }
+    }
   },
 }

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -48,14 +48,13 @@ import { computed } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useRouter } from 'vue-router'
 import { useUserStore } from '../stores/userStore'
-import defaultAvatarUrl from '../assets/default-avatar.svg'
+import { resolveAvatarUrl } from '../utils/avatar'
 
 const router = useRouter()
 const userStore = useUserStore()
 const { isLoggedIn, username, email, avatar } = storeToRefs(userStore)
-const defaultAvatar = defaultAvatarUrl;
 
-const displayAvatar = computed(() => avatar.value || defaultAvatar)
+const displayAvatar = computed(() => resolveAvatarUrl(avatar.value))
 const displayUsername = computed(() => username.value || '未登录')
 const displayEmail = computed(() => email.value || 'not logged in')
 

--- a/src/stores/userStore.ts
+++ b/src/stores/userStore.ts
@@ -126,6 +126,13 @@ export const useUserStore = defineStore('user', {
 
       return result
     },
+    async uploadAvatar(file: File) {
+      const result = await userApi.uploadAvatar(file)
+      if (result.success && result.data) {
+        this.applyUser(result.data)
+      }
+      return result
+    },
     async logout() {
       await userApi.logout()
       this.applyUser(null)

--- a/src/utils/avatar.ts
+++ b/src/utils/avatar.ts
@@ -1,0 +1,10 @@
+import { API_CONFIG } from '../api/config'
+import defaultAvatarUrl from '../assets/default-avatar.svg'
+
+export function resolveAvatarUrl(raw: string | null | undefined): string {
+  if (!raw) return defaultAvatarUrl
+  if (raw.startsWith('http://') || raw.startsWith('https://') || raw.startsWith('data:')) {
+    return raw
+  }
+  return `${API_CONFIG.BASE_URL}${raw}`
+}

--- a/src/views/UserView.vue
+++ b/src/views/UserView.vue
@@ -3,10 +3,22 @@
     <div v-if="isLoggedIn" class="user-account-container">
       <div class="profile-block">
         <div class="profile-content">
-          <img :src="user.avatar || defaultAvatar" class="avatar-img" />
+          <img :src="avatarUrl" class="avatar-img" />
           <div class="profile-meta">
             <div class="user-name">{{ user.username }}</div>
             <div class="user-email">{{ user.email }}</div>
+            <div class="avatar-actions">
+              <input
+                ref="avatarFileInput"
+                type="file"
+                accept="image/png,image/jpeg,image/webp"
+                class="avatar-file-input"
+                @change="onAvatarFileChange"
+              />
+              <el-button size="small" :loading="isUploadingAvatar" @click="onPickAvatar">
+                {{ isUploadingAvatar ? '上传中…' : '修改头像' }}
+              </el-button>
+            </div>
           </div>
         </div>
       </div>
@@ -114,10 +126,9 @@ import { ElMessage } from 'element-plus'
 import { shouldUseUserMockApi } from '../api/config'
 import { userApi } from '../api/user'
 import { useUserStore } from '../stores/userStore'
-import defaultAvatarUrl from '../assets/default-avatar.svg'
+import { resolveAvatarUrl } from '../utils/avatar'
 
 
-const defaultAvatar = defaultAvatarUrl;
 const SEND_CODE_COOLDOWN = 60
 const isMockApi = shouldUseUserMockApi()
 
@@ -157,6 +168,10 @@ const emailForm = reactive({
 })
 const emailCountdown = ref(0)
 let emailCountdownTimer: ReturnType<typeof setInterval> | null = null
+
+const avatarFileInput = ref<HTMLInputElement | null>(null)
+const isUploadingAvatar = ref(false)
+const avatarUrl = computed(() => resolveAvatarUrl(avatar.value))
 
 const isSendingCode = ref(false)
 const verificationCountdown = ref(0)
@@ -403,6 +418,33 @@ async function onUpdateEmail() {
     ElMessage.error(result.message || '邮箱修改失败')
   }
 }
+
+function onPickAvatar() {
+  avatarFileInput.value?.click()
+}
+
+async function onAvatarFileChange(event: Event) {
+  const target = event.target as HTMLInputElement
+  const file = target.files?.[0]
+  if (!file) return
+  if (file.size > 2 * 1024 * 1024) {
+    ElMessage.error('头像不能超过 2MB')
+    target.value = ''
+    return
+  }
+  isUploadingAvatar.value = true
+  try {
+    const result = await userStore.uploadAvatar(file)
+    if (result.success) {
+      ElMessage.success('头像已更新')
+    } else {
+      ElMessage.error(result.message || '上传失败')
+    }
+  } finally {
+    isUploadingAvatar.value = false
+    target.value = ''
+  }
+}
 </script>
 
 <style scoped>
@@ -455,6 +497,17 @@ async function onUpdateEmail() {
   border-radius: 50%;
   background: #f0f0f0;
   margin-bottom: 18px;
+  object-fit: cover;
+}
+
+.avatar-actions {
+  display: flex;
+  justify-content: center;
+  margin-top: 8px;
+}
+
+.avatar-file-input {
+  display: none;
 }
 
 .user-name {


### PR DESCRIPTION
飞书任务板 \`recvk46OASvtLF\`。配套 BUAA-ISET/WildCard_BackEnd#73。

## 改动
- \`UserView.vue\`：账户页头像下方"修改头像"按钮（隐藏 file input），multipart 直传 + 顶部实时刷新
- \`userApi.uploadAvatar\` / \`userStore.uploadAvatar\`
- \`src/utils/avatar.ts::resolveAvatarUrl\`：相对 URL 拼接 \`API_CONFIG.BASE_URL\`，兼容绝对/data:/缺省四种情形
- 顺手修 \`MainLayout.vue\` 左下角头像：之前直传相对 URL 给 \`<img>\` 会 404，现在统一走 resolveAvatarUrl

## 验证
- \`npm run build\`：类型零错误
- \`npm run test:unit\`：88 passed（HomeView 2 个 pre-existing 失败与本 PR 无关）
- E2E：浏览器上传 png/jpeg → 顶部 & 左下角头像同时更新；刷新页面 / 重新登录后仍然展示

Closes #105