### PR TITLE
feat(rule-builder): add tutorial entry in header

### DIFF
--- a/src/views/RuleBuilderView.vue
+++ b/src/views/RuleBuilderView.vue
@@ -7,6 +7,7 @@
       </div>
       <div class="header-actions">
         <el-button @click="backToCenter">返回列表</el-button>
+        <el-button @click="openTutorial">教程</el-button>
         <el-button @click="openJsonImport">导入 JSON</el-button>
         <el-button @click="showJson = !showJson">{{ showJson ? '隐藏 JSON' : '显示 JSON' }}</el-button>
         <el-button type="primary" @click="saveDesign">保存草稿</el-button>
@@ -894,6 +895,11 @@ const uploadCompletedRule = async () => {
 
 const backToCenter = () => {
   void router.push('/creation-center')
+}
+
+const TUTORIAL_URL = 'https://buaa-iset.github.io/WildCard_Docs/tutorials/rule-builder-overview/'
+const openTutorial = () => {
+  window.open(TUTORIAL_URL, '_blank', 'noopener')
 }
 </script>
 


### PR DESCRIPTION
飞书任务板 \`recvk46Z0JVqkn\`。

## 改动
\`RuleBuilderView.vue\` 顶部新增「教程」按钮,新页签跳转到统一文档站:

https://buaa-iset.github.io/WildCard_Docs/tutorials/rule-builder-overview/

## 文档站说明
文档站本身在新建仓库 BUAA-ISET/WildCard_Docs 维护,使用 MkDocs Material 主题。push 到 main 后 GitHub Actions 自动 \`mkdocs build --strict\` 并部署到 GitHub Pages。

站点结构:
- 入门:规则构建总览 + 三个示例(极简对局 / 斗地主炸弹 / 跨牌型压制)
- 参考:组件总览(各 scope 适用矩阵)+ 常见错误速查
- 开发者参考:从 WildCard_BackEnd/doc/ 同步的 10 篇架构与 API 文档

## 验证
- \`npm run build\`:类型零错误
- 站点已上线,HTTP 200

Closes #107