### PR TITLE
fix(api): resolve correct API base URL on production hosts

### DIFF
--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -1,3 +1,9 @@
+const PRODUCTION_API_BASE_URL = 'http://69.197.183.145:3000'
+
+const isProductionHost = (host: string): boolean => {
+    return host === 'isetwildcard.me' || host.endsWith('.github.io')
+}
+
 const resolveBaseUrl = (): string => {
     const configuredBaseUrl = import.meta.env.VITE_API_BASE_URL?.trim()
     if (configuredBaseUrl) {
@@ -5,7 +11,13 @@ const resolveBaseUrl = (): string => {
     }
 
     if (typeof window !== 'undefined') {
-        return `${window.location.protocol}//${window.location.hostname}:3000`
+        const host = window.location.hostname
+        // 生产部署（GH Pages 自定义域名 / *.github.io）没有同主机 BE，
+        // 固定指向中央开发服。本地与 dev 公网 IP 沿用原行为。
+        if (isProductionHost(host)) {
+            return PRODUCTION_API_BASE_URL
+        }
+        return `${window.location.protocol}//${host}:3000`
     }
 
     return 'http://localhost:3000'


### PR DESCRIPTION
见 #119,配套 BUAA-ISET/WildCard_BackEnd#79。`npm run build` 通过,`test:unit` 90/90。merge 后 GH Pages 重新部署即可生效。

Closes #119