### PR TITLE
fix(ci): build SPA before uploading GH Pages artifact

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,28 +1,23 @@
-# Simple workflow for deploying static content to GitHub Pages
+# Build and deploy the Vite SPA to GitHub Pages.
+# 之前的版本上传的是仓库根目录,Pages 上没有可用的 index.html,
+# 浏览器报 "This page isn't working"。
 name: Deploy static content to Pages
 
 on:
-  # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
-  # Single deploy job since we're just deploying
   deploy:
     environment:
       name: github-pages
@@ -31,13 +26,35 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Ensure CNAME and SPA 404 fallback
+        run: |
+          if [ -f public/CNAME ]; then cp public/CNAME dist/CNAME; fi
+          if [ -f CNAME ]; then cp CNAME dist/CNAME; fi
+          # GH Pages serves the same index.html as a 404 fallback so vue-router
+          # routes survive a page refresh.
+          cp dist/index.html dist/404.html
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
-      - name: Upload artifact
+
+      - name: Upload dist as Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
-          path: '.'
+          path: "./dist"
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5


### PR DESCRIPTION
见 #121。

之前 `static.yml` 不跑构建,直接上传仓库源码到 Pages,导致 `http://isetwildcard.me/` 报 "This page isn't working"。本 PR 加上 `npm ci` + `npm run build`,上传 `./dist`,复制 CNAME,把 `index.html` 复制成 `404.html` 兜底 vue-router 刷新。

merge 后约 2 分钟生产就该恢复。

Closes #121