### PR TITLE
test: expand frontend implemented behavior coverage

### DIFF
--- a/cypress/e2e/battle-flow.cy.ts
+++ b/cypress/e2e/battle-flow.cy.ts
@@ -1,0 +1,107 @@
+/// <reference types="cypress" />
+
+const user = {
+  id: 'user-001',
+  username: 'alice',
+  email: 'alice@example.com',
+  avatar: '',
+  token: 'jwt-token',
+}
+
+function navigateInApp(path: string) {
+  cy.window().then((win) => {
+    win.history.pushState({}, '', path)
+    win.dispatchEvent(new win.PopStateEvent('popstate'))
+  })
+  cy.location('pathname').should('eq', path)
+}
+
+function loginAndVisit(path: string) {
+  cy.intercept('POST', '**/api/user/login', {
+    success: true,
+    data: user,
+  }).as('loginForRoute')
+
+  cy.visit('/user-info', { timeout: 60000 })
+  cy.get('input').eq(0).type(user.email)
+  cy.get('input').eq(1).type('password123')
+  cy.contains('button', '登录').click()
+  cy.wait('@loginForRoute')
+  cy.contains('.user-name', user.username).should('be.visible')
+  navigateInApp(path)
+}
+
+const snapshot = {
+  sessionId: 'session-1',
+  roomCode: 'ROOM42',
+  ruleId: 'rule-1',
+  status: 'playing',
+  currentPlayerId: 'user-001',
+  roundTime: 30,
+  deadlineAt: null,
+  players: [
+    { id: 'user-001', username: 'alice', avatar: '', cardCount: 1, online: true },
+    { id: 'user-002', username: 'bob', avatar: '', cardCount: 2, online: true },
+  ],
+  table: {
+    playedCards: [{ id: 'table-card', properties: { point: 13, suit: 1 }, display: { rank: 'K', suit: 'H' } }],
+    passStreak: 0,
+    lastPlayedBy: 'user-002',
+  },
+  handCards: [
+    { id: 'card-a', properties: { point: 14, suit: 0 }, display: { rank: 'A', suit: 'S' } },
+  ],
+  pendingAction: {
+    actionId: 'action-1',
+    playerId: 'user-001',
+    actionType: 'playCards',
+    canSkip: true,
+  },
+  lastAction: null,
+  winnerIds: [],
+}
+
+describe('战斗页交互', () => {
+  beforeEach(() => {
+    cy.clearCookies()
+    cy.clearLocalStorage()
+    cy.clearAllSessionStorage()
+  })
+
+  it('加载手牌、选择手牌并提交出牌动作', () => {
+    cy.intercept('GET', '**/api/games/current?roomCode=ROOM42', {
+      success: true,
+      data: snapshot,
+    }).as('currentGame')
+    cy.intercept('POST', '**/api/games/session-1/actions/action-1/play-cards', {
+      success: true,
+      data: {
+        ...snapshot,
+        handCards: [],
+        table: {
+          ...snapshot.table,
+          playedCards: snapshot.handCards,
+          lastPlayedBy: 'user-001',
+        },
+        pendingAction: null,
+        lastAction: {
+          playerId: 'user-001',
+          action: 'playCards',
+          cards: snapshot.handCards,
+          message: '打出了 1 张牌',
+          turn: 1,
+        },
+      },
+    }).as('playCards')
+
+    loginAndVisit('/game/ROOM42/battle')
+    cy.wait('@currentGame')
+
+    cy.contains('.turn-text', '轮到你出牌').should('be.visible')
+    cy.contains('.hand-card', 'A').click()
+    cy.get('.hand-card.selected').should('have.length', 1)
+    cy.contains('button', 'PLAY').click()
+    cy.wait('@playCards').its('request.body').should('deep.equal', { cardIds: ['card-a'] })
+    cy.contains('.turn-text', '打出了 1 张牌').should('be.visible')
+  })
+})

--- a/cypress/e2e/card-style.cy.ts
+++ b/cypress/e2e/card-style.cy.ts
@@ -1,0 +1,94 @@
+/// <reference types="cypress" />
+
+const user = {
+  id: 'user-001',
+  username: 'alice',
+  email: 'alice@example.com',
+  avatar: '',
+  token: 'jwt-token',
+}
+
+function navigateInApp(path: string) {
+  cy.window().then((win) => {
+    win.history.pushState({}, '', path)
+    win.dispatchEvent(new win.PopStateEvent('popstate'))
+  })
+  cy.location('pathname').should('eq', path)
+}
+
+function loginAndVisit(path: string) {
+  cy.intercept('POST', '**/api/user/login', {
+    success: true,
+    data: user,
+  }).as('loginForRoute')
+
+  cy.visit('/user-info', { timeout: 60000 })
+  cy.get('input').eq(0).type(user.email)
+  cy.get('input').eq(1).type('password123')
+  cy.contains('button', '登录').click()
+  cy.wait('@loginForRoute')
+  cy.contains('.user-name', user.username).should('be.visible')
+  navigateInApp(path)
+}
+
+describe('卡牌样式设置', () => {
+  beforeEach(() => {
+    cy.clearCookies()
+    cy.clearLocalStorage()
+    cy.clearAllSessionStorage()
+  })
+
+  it('保存样式设置并在重新进入页面后恢复', () => {
+    loginAndVisit('/card-style')
+
+    cy.contains('h2', '卡牌样式设置').should('be.visible')
+    cy.get('select').eq(0).select('Times New Roman')
+    cy.get('select').eq(1).select('柔和蓝紫')
+    cy.get('input').eq(0).clear().type('https://example.test/front.png')
+    cy.get('input').eq(1).clear().type('https://example.test/back.png')
+
+    cy.window().then((win) => {
+      expect(JSON.parse(win.localStorage.getItem('wildcard-card-style') || '{}')).to.deep.equal({
+        fontFamily: "'Times New Roman', serif",
+        theme: 'soft',
+        frontImage: 'https://example.test/front.png',
+        backImage: 'https://example.test/back.png',
+      })
+    })
+
+    navigateInApp('/user-info')
+    navigateInApp('/card-style')
+    cy.get('select').eq(0).should('have.value', "'Times New Roman', serif")
+    cy.get('select').eq(1).should('have.value', 'soft')
+    cy.get('input').eq(0).should('have.value', 'https://example.test/front.png')
+    cy.get('input').eq(1).should('have.value', 'https://example.test/back.png')
+  })
+
+  it('可以从已保存样式恢复默认样式', () => {
+    loginAndVisit('/card-style')
+    cy.window().then((win) => {
+      win.localStorage.setItem('wildcard-card-style', JSON.stringify({
+        fontFamily: "'Courier New', monospace",
+        theme: 'green',
+        frontImage: 'https://example.test/front.png',
+        backImage: 'https://example.test/back.png',
+      }))
+    })
+    navigateInApp('/user-info')
+    navigateInApp('/card-style')
+
+    cy.get('select').eq(1).should('have.value', 'green')
+    cy.get('.plain-btn').click()
+
+    cy.get('select').eq(0).should('have.value', 'Arial, sans-serif')
+    cy.get('select').eq(1).should('have.value', 'classic')
+    cy.window().then((win) => {
+      expect(JSON.parse(win.localStorage.getItem('wildcard-card-style') || '{}')).to.deep.equal({
+        fontFamily: 'Arial, sans-serif',
+        theme: 'classic',
+        frontImage: '',
+        backImage: '',
+      })
+    })
+  })
+})

--- a/cypress/e2e/creation-center.cy.ts
+++ b/cypress/e2e/creation-center.cy.ts
@@ -1,0 +1,108 @@
+/// <reference types="cypress" />
+
+const user = {
+  id: 'user-001',
+  username: 'alice',
+  email: 'alice@example.com',
+  avatar: '',
+  token: 'jwt-token',
+}
+
+function navigateInApp(path: string) {
+  cy.window().then((win) => {
+    win.history.pushState({}, '', path)
+    win.dispatchEvent(new win.PopStateEvent('popstate'))
+  })
+  cy.location('pathname').should('eq', path)
+}
+
+function loginAndVisit(path: string) {
+  cy.intercept('POST', '**/api/user/login', {
+    success: true,
+    data: user,
+  }).as('loginForRoute')
+
+  cy.visit('/user-info', { timeout: 60000 })
+  cy.get('input').eq(0).type(user.email)
+  cy.get('input').eq(1).type('password123')
+  cy.contains('button', '登录').click()
+  cy.wait('@loginForRoute')
+  cy.contains('.user-name', user.username).should('be.visible')
+  navigateInApp(path)
+}
+
+describe('创作中心', () => {
+  beforeEach(() => {
+    cy.clearCookies()
+    cy.clearLocalStorage()
+    cy.clearAllSessionStorage()
+  })
+
+  it('展示草稿列表', () => {
+    cy.intercept('GET', '**/api/rules/drafts', {
+      success: true,
+      data: [
+        {
+          id: 'draft 1',
+          name: '单张规则',
+          playerCount: 2,
+          description: '单张出牌流程',
+          status: 'draft',
+          updatedAt: 1700000000000,
+        },
+      ],
+    }).as('listDrafts')
+
+    loginAndVisit('/creation-center')
+    cy.wait('@listDrafts')
+
+    cy.contains('.rule-row', '单张规则').should('be.visible')
+  })
+
+  it('创建新规则会进入规则构建页', () => {
+    cy.intercept('GET', '**/api/rules/drafts', { success: true, data: [] })
+
+    loginAndVisit('/creation-center')
+    cy.contains('button', '创建新规则').click()
+
+    cy.location('pathname').should('eq', '/creation-center/new')
+    cy.contains('h1', '规则构建').should('be.visible')
+  })
+
+  it('确认后删除草稿并从列表移除', () => {
+    cy.intercept('GET', '**/api/rules/drafts', {
+      success: true,
+      data: [
+        {
+          id: 'draft-delete',
+          name: '待删除规则',
+          playerCount: 2,
+          description: 'delete me',
+          status: 'draft',
+          updatedAt: 1700000000000,
+        },
+      ],
+    })
+    cy.intercept('DELETE', '**/api/rules/drafts/draft-delete', {
+      success: true,
+      data: {
+        id: 'draft-delete',
+        name: '待删除规则',
+        playerCount: 2,
+        description: 'delete me',
+        status: 'draft',
+        updatedAt: 1700000000000,
+      },
+    }).as('deleteDraft')
+
+    loginAndVisit('/creation-center')
+    cy.contains('.rule-row', '待删除规则').within(() => {
+      cy.contains('button', '删除').click()
+    })
+    cy.contains('.el-message-box', '删除规则').should('be.visible')
+    cy.get('.el-message-box').contains('button', '删除').click()
+    cy.wait('@deleteDraft')
+
+    cy.contains('.rule-row', '待删除规则').should('not.exist')
+  })
+})

--- a/cypress/e2e/room-flow.cy.ts
+++ b/cypress/e2e/room-flow.cy.ts
@@ -1,0 +1,93 @@
+/// <reference types="cypress" />
+
+const user = {
+  id: 'user-001',
+  username: 'alice',
+  email: 'alice@example.com',
+  avatar: '',
+  token: 'jwt-token',
+}
+
+function navigateInApp(path: string) {
+  cy.window().then((win) => {
+    win.history.pushState({}, '', path)
+    win.dispatchEvent(new win.PopStateEvent('popstate'))
+  })
+  cy.location('pathname').should('eq', path)
+}
+
+function loginAndVisit(path: string) {
+  cy.intercept('POST', '**/api/user/login', {
+    success: true,
+    data: user,
+  }).as('loginForRoute')
+
+  cy.visit('/user-info', { timeout: 60000 })
+  cy.get('input').eq(0).type(user.email)
+  cy.get('input').eq(1).type('password123')
+  cy.contains('button', '登录').click()
+  cy.wait('@loginForRoute')
+  cy.contains('.user-name', user.username).should('be.visible')
+  navigateInApp(path)
+}
+
+const room = {
+  id: 'room-1',
+  code: 'ROOM42',
+  host_id: 'user-001',
+  player_count: 2,
+  round_time: 30,
+  rule_id: 'rule-1',
+  rule_name: 'Tiny Demo',
+  password: null,
+  has_password: false,
+  players: [
+    { id: 'user-001', username: 'alice', avatar: '', is_ready: true, joined_at: 1 },
+  ],
+  status: 'waiting',
+}
+
+describe('房间主流程', () => {
+  beforeEach(() => {
+    cy.clearCookies()
+    cy.clearLocalStorage()
+    cy.clearAllSessionStorage()
+  })
+
+  it('创建房间后进入准备房间', () => {
+    cy.intercept('GET', '**/api/room/rules', {
+      success: true,
+      data: [{ id: 'rule-1', name: 'Tiny Demo', player_count: 2, description: 'demo' }],
+    }).as('rules')
+    cy.intercept('POST', '**/api/room/create', { success: true, data: room }).as('createRoom')
+    cy.intercept('GET', '**/api/room/current?code=ROOM42', { success: true, data: room }).as('currentRoom')
+
+    loginAndVisit('/create-room')
+    cy.wait('@rules')
+    cy.contains('button', '创建房间').click()
+    cy.wait('@createRoom')
+
+    cy.location('pathname').should('eq', '/game/ROOM42')
+    cy.wait('@currentRoom')
+    cy.contains('.summary-value', 'ROOM42').should('be.visible')
+    cy.contains('.summary-value', 'Tiny Demo').should('be.visible')
+  })
+
+  it('加入无密码房间后进入准备房间', () => {
+    cy.intercept('GET', '**/api/room/check-password?code=ROOM42', {
+      success: true,
+      hasPassword: false,
+    }).as('checkPassword')
+    cy.intercept('POST', '**/api/room/join', { success: true, data: room }).as('joinRoom')
+    cy.intercept('GET', '**/api/room/current?code=ROOM42', { success: true, data: room })
+
+    loginAndVisit('/join-room')
+    cy.get('.join-room-input input').type('ROOM42')
+    cy.contains('button', '加入房间').click()
+    cy.wait('@checkPassword')
+    cy.wait('@joinRoom')
+
+    cy.location('pathname').should('eq', '/game/ROOM42')
+    cy.contains('.summary-value', 'ROOM42').should('be.visible')
+  })
+})

--- a/cypress/e2e/user-auth.cy.ts
+++ b/cypress/e2e/user-auth.cy.ts
@@ -26,4 +26,40 @@ describe('用户认证页面', () => {
     cy.location('pathname').should('eq', '/user-info')
     cy.contains('.el-tabs__item.is-active', '登录').should('be.visible')
   })
+
+  it('登录成功后展示账户资料', () => {
+    cy.intercept('POST', '**/api/user/login', {
+      success: true,
+      data: {
+        id: 'user-001',
+        username: 'alice',
+        email: 'alice@example.com',
+        avatar: '',
+        token: 'jwt-token',
+      },
+    }).as('login')
+
+    cy.get('input').eq(0).type('alice@example.com')
+    cy.get('input').eq(1).type('password123')
+    cy.contains('button', '登录').click()
+    cy.wait('@login')
+
+    cy.contains('.user-name', 'alice').should('be.visible')
+    cy.contains('.user-email', 'alice@example.com').should('be.visible')
+    cy.window().then((win) => {
+      const sessionKeys = Array.from({ length: win.sessionStorage.length }, (_value, index) => win.sessionStorage.key(index))
+        .filter((key): key is string => Boolean(key))
+      const userKey = sessionKeys.find((key) => key.endsWith(':user'))
+      const tokenKey = sessionKeys.find((key) => key.endsWith(':auth-token'))
+
+      expect(userKey).to.be.a('string')
+      expect(JSON.parse(win.sessionStorage.getItem(userKey || '') || '{}')).to.include({
+        id: 'user-001',
+        username: 'alice',
+        email: 'alice@example.com',
+      })
+      expect(tokenKey).to.be.a('string')
+      expect(win.sessionStorage.getItem(tokenKey || '')).to.eq('jwt-token')
+    })
+  })
 })

--- a/src/api/__tests__/game.spec.ts
+++ b/src/api/__tests__/game.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { USER_STORAGE_KEY } from '../../utils/storageNamespace'
 import { gameApi } from '../game'
+import { roomApi } from '../room'
 
 const originalFetch = globalThis.fetch
 
@@ -112,5 +113,94 @@ describe('gameApi', () => {
         body: JSON.stringify({}),
       }),
     )
+  })
+
+  it('normalizes engine-style game sessions with room metadata', async () => {
+    const engineSession = {
+      id: 'engine-session-1',
+      room_code: 'ROOM01',
+      status: 'playing',
+      players: [
+        { id: 'user-001', properties: { hand_count: 1 } },
+        { id: 'user-002', properties: { hand_count: 2 } },
+      ],
+      table: { player_index: 1 },
+      hands: {
+        'user-001': [{ id: 'card-a', properties: { point: 1, suit: 0 } }],
+        'user-002': [
+          { id: 'card-k', properties: { point: 13, suit: 1 } },
+          { id: 'card-q', properties: { point: 12, suit: 2 } },
+        ],
+      },
+      pending_action: {
+        id: 'action-engine-1',
+        player_id: 'user-002',
+        component_type: 21,
+        timer: 30,
+      },
+      last_successful_play: {
+        player_id: 'user-001',
+        cards: [{ id: 'card-prev', properties: { point: 13, suit: 1 } }],
+      },
+      settlement_results: { 'user-002': 1 },
+      last_action_player_id: 'user-001',
+      last_action_cards: [{ id: 'card-prev', properties: { point: 13, suit: 1 } }],
+      last_action_skipped: false,
+    }
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true, data: engineSession })),
+    )
+    globalThis.fetch = fetchMock
+    vi.spyOn(roomApi, 'getRoomByCode').mockResolvedValue({
+      success: true,
+      data: {
+        id: 'room-1',
+        code: 'ROOM01',
+        hostId: 'user-001',
+        playerCount: 2,
+        roundTime: 60,
+        ruleId: 'rule-engine',
+        ruleName: 'Engine Rule',
+        password: null,
+        players: [
+          { id: 'user-001', username: 'alice', avatar: '/alice.png', isReady: true },
+          { id: 'user-002', username: 'bob', avatar: '/bob.png', isReady: true },
+        ],
+        status: 'playing',
+      },
+    })
+
+    const result = await gameApi.getCurrent('ROOM 01')
+
+    expect(roomApi.getRoomByCode).toHaveBeenCalledWith('ROOM 01')
+    expect(result.success).toBe(true)
+    expect(result.data).toMatchObject({
+      sessionId: 'engine-session-1',
+      roomCode: 'ROOM01',
+      ruleId: 'rule-engine',
+      currentPlayerId: 'user-002',
+      roundTime: 60,
+      players: [
+        { id: 'user-001', username: 'alice', cardCount: 1 },
+        { id: 'user-002', username: 'bob', cardCount: 2, finished: true },
+      ],
+      handCards: [{ id: 'card-a', display: { rank: 'A', suit: 'S' } }],
+      table: {
+        playedCards: [{ id: 'card-prev', display: { rank: 'K', suit: 'H' } }],
+        lastPlayedBy: 'user-001',
+      },
+      pendingAction: {
+        actionId: 'action-engine-1',
+        playerId: 'user-002',
+        actionType: 'playCards',
+        canSkip: true,
+      },
+      lastAction: {
+        playerId: 'user-001',
+        action: 'playCards',
+        cards: [{ id: 'card-prev', display: { rank: 'K', suit: 'H' } }],
+      },
+      winnerIds: ['user-002'],
+    })
   })
 })

--- a/src/api/__tests__/room.spec.ts
+++ b/src/api/__tests__/room.spec.ts
@@ -144,4 +144,36 @@ describe('roomApi', () => {
     expect(getRoomEntryPath({ code: 'ROOM 01', status: 'playing' })).toBe('/game/ROOM%2001/battle')
     expect(getRoomEntryPath({ code: 'ROOM 01', status: 'waiting' })).toBe('/game/ROOM%2001')
   })
+
+  it('clears current room storage when no active backend room exists', async () => {
+    window.sessionStorage.setItem(scopedStorageKey('current-room-code'), 'ROOM01')
+    window.sessionStorage.setItem('currentRoomCode', 'ROOM01')
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true, data: null })),
+    )
+
+    await expect(roomApi.getCurrentRoom()).resolves.toEqual({ success: true, data: null })
+
+    expect(window.sessionStorage.getItem(scopedStorageKey('current-room-code'))).toBeNull()
+    expect(window.sessionStorage.getItem('currentRoomCode')).toBeNull()
+  })
+
+  it('requests room rules with encoded room ids and returns rule data', async () => {
+    const roomRule = {
+      room_id: 'room 01',
+      rule: { name: 'Tiny Demo', player_count: 2 },
+    }
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true, data: roomRule })),
+    )
+
+    await expect(roomApi.getRoomRule('room 01')).resolves.toEqual({
+      success: true,
+      data: roomRule,
+    })
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/room/rule/get?room_id=room%2001'),
+      expect.objectContaining({ method: 'GET' }),
+    )
+  })
 })

--- a/src/utils/__tests__/ruleBuilder.spec.ts
+++ b/src/utils/__tests__/ruleBuilder.spec.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest'
+import type { RuleEdgeDraft } from '../../types/ruleBuilder'
+import {
+  componentTemplates,
+  createCardset,
+  createEmptyGraph,
+  createInitialDesign,
+  createNodeFromTemplate,
+  createProperty,
+  createRuleObjectPool,
+  exportFlowGraph,
+  exportRuleDesign,
+  importRuleDesign,
+  validateRuleDesign,
+} from '../ruleBuilder'
+
+function templateOf(componentType: number) {
+  const template = componentTemplates.find(item => item.componentType === componentType)
+  if (!template) {
+    throw new Error(`missing template ${componentType}`)
+  }
+  return template
+}
+
+describe('ruleBuilder utilities', () => {
+  it('creates a runtime object pool from player, card, and table defaults', () => {
+    const design = createInitialDesign()
+    design.info.playerCount = 2
+    design.classes.player.userProperties = [{ ...createProperty('积分'), default: 5 }]
+    design.classes.table.userProperties = [{ ...createProperty('回合'), default: 1 }]
+    design.classes.card.defaultProperties = [
+      {
+        ...createProperty('点数'),
+        type: 'enum',
+        default: 1,
+        config: [
+          { display: 'A', value: 1 },
+          { display: 'K', value: 13 },
+        ],
+      },
+      {
+        ...createProperty('花色'),
+        type: 'enum',
+        default: 0,
+        config: [
+          { display: '黑桃', value: 0 },
+          { display: '红桃', value: 1 },
+        ],
+      },
+    ]
+
+    const pool = createRuleObjectPool(design)
+
+    expect(pool.players).toHaveLength(2)
+    expect(pool.players[0].properties).toMatchObject({ 手牌数: 0, 积分: 5 })
+    expect(pool.cards).toHaveLength(4)
+    expect(pool.cards.map(card => card.properties)).toContainEqual({ 点数: 1, 花色: 0 })
+    expect(pool.cards.map(card => card.properties)).toContainEqual({ 点数: 13, 花色: 1 })
+    expect(pool.table.properties).toMatchObject({ 回合: 1, 本轮应出牌者: 'player_0' })
+    expect(pool.table.properties.玩家池).toEqual(pool.players)
+    expect(pool.table.properties.卡牌池).toEqual(pool.cards)
+  })
+
+  it('exports flow ordinals, branch edges, and semantic input references', () => {
+    const graph = createEmptyGraph('match')
+    const start = graph.nodes[0]
+    const value = createNodeFromTemplate(templateOf(8), 'match', 180, 120)
+    const condition = createNodeFromTemplate(templateOf(16), 'match', 300, 120)
+    const shuffle = createNodeFromTemplate(templateOf(19), 'match', 500, 80)
+    const end = createNodeFromTemplate(templateOf(18), 'match', 700, 120)
+
+    condition.data.content = { condition: value.id }
+    graph.nodes.push(value, condition, shuffle, end)
+    graph.edges = [
+      { id: 'edge-start-condition', source: start.id, target: condition.id },
+      { id: 'edge-value-condition', source: value.id, target: condition.id, targetHandle: 'condition' },
+      { id: 'edge-condition-true', source: condition.id, target: shuffle.id, sourceHandle: 'true' },
+      { id: 'edge-condition-false', source: condition.id, target: end.id, sourceHandle: 'false' },
+      { id: 'edge-shuffle-end', source: shuffle.id, target: end.id },
+    ] satisfies RuleEdgeDraft[]
+
+    const exported = exportFlowGraph(graph)
+
+    expect(exported['1']).toMatchObject({ type: 17, content: { next: '3' } })
+    expect(exported['2']).toMatchObject({ type: 8, content: { value: 0 } })
+    expect(exported['2'].content).not.toHaveProperty('next')
+    expect(exported['3']).toMatchObject({
+      type: 16,
+      content: { condition: '2', next_true: '4', next_false: '5' },
+    })
+    expect(exported['4']).toMatchObject({ type: 19, content: { next: '5' } })
+  })
+
+  it('exports cardset comparison names and imports them back to draft ids', () => {
+    const design = createInitialDesign()
+    design.cardsets.push(createCardset('对子', 2))
+    design.cardsetComparisons[0].cardsetA = '1'
+    design.cardsetComparisons[0].cardsetB = '2'
+
+    const exported = exportRuleDesign(design)
+
+    expect(exported.cardset_comparisons['1']).toMatchObject({
+      cardsetA: '单张',
+      cardsetB: '对子',
+    })
+
+    const imported = importRuleDesign(exported)
+
+    expect(imported.cardsetComparisons[0]).toMatchObject({
+      cardsetA: '1',
+      cardsetB: '2',
+    })
+  })
+
+  it('reports strict runtime gaps for incomplete executable flows', () => {
+    const design = createInitialDesign()
+    design.info.name = '   '
+
+    const messages = validateRuleDesign(design, { strictRuntime: true }).map(result => result.message)
+
+    expect(messages).toContain('规则名称不能为空')
+    expect(messages).toContain('对局流程需要连接到「结束对局」组件')
+    expect(messages).toContain('结算流程需要包含「结算结束」组件')
+    expect(messages).toContain('牌型「单张」构建流程需要包含「匹配返回」组件')
+    expect(messages).toContain('牌型比较「牌型比较1」流程需要包含「比较返回」组件')
+  })
+})

--- a/src/views/__tests__/CardStyleView.spec.ts
+++ b/src/views/__tests__/CardStyleView.spec.ts
@@ -1,0 +1,82 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it } from 'vitest'
+import CardStyleView from '../CardStyleView.vue'
+
+const storageKey = 'wildcard-card-style'
+
+describe('CardStyleView', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('renders the default card style when no saved style exists', () => {
+    const wrapper = mount(CardStyleView)
+    const selects = wrapper.findAll('select')
+    const inputs = wrapper.findAll('input')
+
+    expect(selects[0].element.value).toBe('Arial, sans-serif')
+    expect(selects[1].element.value).toBe('classic')
+    expect(inputs[0].element.value).toBe('')
+    expect(inputs[1].element.value).toBe('')
+    expect(wrapper.find('.front-card').classes()).toContain('theme-classic')
+  })
+
+  it('loads a saved card style from localStorage', () => {
+    window.localStorage.setItem(storageKey, JSON.stringify({
+      fontFamily: `'Courier New', monospace`,
+      theme: 'green',
+      frontImage: 'https://example.test/front.png',
+      backImage: 'https://example.test/back.png',
+    }))
+
+    const wrapper = mount(CardStyleView)
+    const selects = wrapper.findAll('select')
+    const inputs = wrapper.findAll('input')
+
+    expect(selects[0].element.value).toBe(`'Courier New', monospace`)
+    expect(selects[1].element.value).toBe('green')
+    expect(inputs[0].element.value).toBe('https://example.test/front.png')
+    expect(inputs[1].element.value).toBe('https://example.test/back.png')
+    expect(wrapper.find('.front-card').classes()).toContain('theme-green')
+  })
+
+  it('persists changed controls to localStorage', async () => {
+    const wrapper = mount(CardStyleView)
+    const selects = wrapper.findAll('select')
+    const inputs = wrapper.findAll('input')
+
+    await selects[0].setValue(`'Times New Roman', serif`)
+    await selects[1].setValue('soft')
+    await inputs[0].setValue('https://example.test/front.jpg')
+    await inputs[1].setValue('https://example.test/back.jpg')
+
+    expect(JSON.parse(window.localStorage.getItem(storageKey) || '{}')).toEqual({
+      fontFamily: `'Times New Roman', serif`,
+      theme: 'soft',
+      frontImage: 'https://example.test/front.jpg',
+      backImage: 'https://example.test/back.jpg',
+    })
+  })
+
+  it('resets the saved style back to defaults', async () => {
+    window.localStorage.setItem(storageKey, JSON.stringify({
+      fontFamily: `'Courier New', monospace`,
+      theme: 'green',
+      frontImage: 'https://example.test/front.png',
+      backImage: 'https://example.test/back.png',
+    }))
+
+    const wrapper = mount(CardStyleView)
+
+    await wrapper.find('.plain-btn').trigger('click')
+
+    expect(JSON.parse(window.localStorage.getItem(storageKey) || '{}')).toEqual({
+      fontFamily: 'Arial, sans-serif',
+      theme: 'classic',
+      frontImage: '',
+      backImage: '',
+    })
+    expect(wrapper.findAll('select')[1].element.value).toBe('classic')
+    expect(wrapper.findAll('input')[0].element.value).toBe('')
+  })
+})

--- a/src/views/__tests__/CreationCenterView.spec.ts
+++ b/src/views/__tests__/CreationCenterView.spec.ts
@@ -1,0 +1,125 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import { ruleApi } from '../../api/rule'
+import { elementPlusStubs } from '../../test-utils/elementPlusStubs'
+import CreationCenterView from '../CreationCenterView.vue'
+
+const push = vi.fn()
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push }),
+}))
+
+vi.mock('../../api/rule', () => ({
+  ruleApi: {
+    listDrafts: vi.fn(),
+    deleteDraft: vi.fn(),
+  },
+}))
+
+vi.mock('element-plus', async () => {
+  const actual = await vi.importActual<typeof import('element-plus')>('element-plus')
+
+  return {
+    ...actual,
+    ElMessage: {
+      success: vi.fn(),
+      error: vi.fn(),
+    },
+    ElMessageBox: {
+      confirm: vi.fn(),
+    },
+  }
+})
+
+const drafts = [
+  {
+    id: 'draft 1',
+    name: 'Rule One',
+    playerCount: 2,
+    description: 'first rule',
+    status: 'draft' as const,
+    updatedAt: 1_700_000_000_000,
+  },
+  {
+    id: 'draft-2',
+    name: 'Rule Two',
+    playerCount: 4,
+    description: '',
+    status: 'published' as const,
+    updatedAt: 1_700_100_000_000,
+  },
+]
+
+describe('CreationCenterView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows the empty state and navigates to a new draft', async () => {
+    vi.mocked(ruleApi.listDrafts).mockResolvedValue({ success: true, data: [] })
+
+    const wrapper = mount(CreationCenterView, {
+      global: { stubs: elementPlusStubs },
+    })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('暂无规则')
+
+    const createButton = wrapper.findAll('button').find(button => button.text().includes('创建新规则'))
+    await createButton?.trigger('click')
+
+    expect(push).toHaveBeenCalledWith('/creation-center/new')
+  })
+
+  it('renders draft rows and opens the selected draft', async () => {
+    vi.mocked(ruleApi.listDrafts).mockResolvedValue({ success: true, data: drafts })
+
+    const wrapper = mount(CreationCenterView, {
+      global: { stubs: elementPlusStubs },
+    })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Rule One')
+    expect(wrapper.text()).toContain('Rule Two')
+
+    await wrapper.find('.rule-row').trigger('click')
+
+    expect(push).toHaveBeenCalledWith('/creation-center/draft%201')
+  })
+
+  it('deletes a confirmed single draft and updates the list', async () => {
+    vi.mocked(ruleApi.listDrafts).mockResolvedValue({ success: true, data: [drafts[0]] })
+    vi.mocked(ElMessageBox.confirm).mockResolvedValue(undefined as never)
+    vi.mocked(ruleApi.deleteDraft).mockResolvedValue({ success: true, data: drafts[0] })
+
+    const wrapper = mount(CreationCenterView, {
+      global: { stubs: elementPlusStubs },
+    })
+    await flushPromises()
+
+    await wrapper.find('.delete-action').trigger('click')
+    await flushPromises()
+
+    expect(ElMessageBox.confirm).toHaveBeenCalledWith(
+      '确定要删除规则“Rule One”吗？删除后无法恢复。',
+      '删除规则',
+      expect.any(Object),
+    )
+    expect(ruleApi.deleteDraft).toHaveBeenCalledWith('draft 1')
+    expect(wrapper.find('.rule-row').exists()).toBe(false)
+    expect(ElMessage.success).toHaveBeenCalledWith('规则已删除')
+  })
+
+  it('shows an error when drafts fail to load', async () => {
+    vi.mocked(ruleApi.listDrafts).mockResolvedValue({ success: false, message: '规则列表不可用' })
+
+    mount(CreationCenterView, {
+      global: { stubs: elementPlusStubs },
+    })
+    await flushPromises()
+
+    expect(ElMessage.error).toHaveBeenCalledWith('规则列表不可用')
+  })
+})


### PR DESCRIPTION
Closes #123.\n\nSummary:\n- Add unit coverage for rule builder helpers, card style persistence, creation center behavior, and room/game API normalization.\n- Add Cypress e2e coverage for auth, room create/join, battle play action, card style persistence, and creation center draft deletion.\n- Keep changes limited to test files.\n\nTest plan:\n- npm run test:unit\n- VITE_ENABLE_TEST_SANDBOX=true npm run build\n- npx cypress run --browser electron --config baseUrl=http://127.0.0.1:4873