### PR TITLE
test: cover room API and room flow

### DIFF
--- a/cypress/e2e/room-flow.cy.ts
+++ b/cypress/e2e/room-flow.cy.ts
@@ -1,0 +1,93 @@
+/// <reference types="cypress" />
+
+const user = {
+  id: 'user-001',
+  username: 'alice',
+  email: 'alice@example.com',
+  avatar: '',
+  token: 'jwt-token',
+}
+
+function navigateInApp(path: string) {
+  cy.window().then((win) => {
+    win.history.pushState({}, '', path)
+    win.dispatchEvent(new win.PopStateEvent('popstate'))
+  })
+  cy.location('pathname').should('eq', path)
+}
+
+function loginAndVisit(path: string) {
+  cy.intercept('POST', '**/api/user/login', {
+    success: true,
+    data: user,
+  }).as('loginForRoute')
+
+  cy.visit('/user-info', { timeout: 60000 })
+  cy.get('input').eq(0).type(user.email)
+  cy.get('input').eq(1).type('password123')
+  cy.contains('button', '登录').click()
+  cy.wait('@loginForRoute')
+  cy.contains('.user-name', user.username).should('be.visible')
+  navigateInApp(path)
+}
+
+const room = {
+  id: 'room-1',
+  code: 'ROOM42',
+  host_id: 'user-001',
+  player_count: 2,
+  round_time: 30,
+  rule_id: 'rule-1',
+  rule_name: 'Tiny Demo',
+  password: null,
+  has_password: false,
+  players: [
+    { id: 'user-001', username: 'alice', avatar: '', is_ready: true, joined_at: 1 },
+  ],
+  status: 'waiting',
+}
+
+describe('房间主流程', () => {
+  beforeEach(() => {
+    cy.clearCookies()
+    cy.clearLocalStorage()
+    cy.clearAllSessionStorage()
+  })
+
+  it('创建房间后进入准备房间', () => {
+    cy.intercept('GET', '**/api/room/rules', {
+      success: true,
+      data: [{ id: 'rule-1', name: 'Tiny Demo', player_count: 2, description: 'demo' }],
+    }).as('rules')
+    cy.intercept('POST', '**/api/room/create', { success: true, data: room }).as('createRoom')
+    cy.intercept('GET', '**/api/room/current?code=ROOM42', { success: true, data: room }).as('currentRoom')
+
+    loginAndVisit('/create-room')
+    cy.wait('@rules')
+    cy.contains('button', '创建房间').click()
+    cy.wait('@createRoom')
+
+    cy.location('pathname').should('eq', '/game/ROOM42')
+    cy.wait('@currentRoom')
+    cy.contains('.summary-value', 'ROOM42').should('be.visible')
+    cy.contains('.summary-value', 'Tiny Demo').should('be.visible')
+  })
+
+  it('加入无密码房间后进入准备房间', () => {
+    cy.intercept('GET', '**/api/room/check-password?code=ROOM42', {
+      success: true,
+      hasPassword: false,
+    }).as('checkPassword')
+    cy.intercept('POST', '**/api/room/join', { success: true, data: room }).as('joinRoom')
+    cy.intercept('GET', '**/api/room/current?code=ROOM42', { success: true, data: room })
+
+    loginAndVisit('/join-room')
+    cy.get('.join-room-input input').type('ROOM42')
+    cy.contains('button', '加入房间').click()
+    cy.wait('@checkPassword')
+    cy.wait('@joinRoom')
+
+    cy.location('pathname').should('eq', '/game/ROOM42')
+    cy.contains('.summary-value', 'ROOM42').should('be.visible')
+  })
+})

--- a/src/api/__tests__/room.spec.ts
+++ b/src/api/__tests__/room.spec.ts
@@ -144,4 +144,36 @@ describe('roomApi', () => {
     expect(getRoomEntryPath({ code: 'ROOM 01', status: 'playing' })).toBe('/game/ROOM%2001/battle')
     expect(getRoomEntryPath({ code: 'ROOM 01', status: 'waiting' })).toBe('/game/ROOM%2001')
   })
+
+  it('clears current room storage when no active backend room exists', async () => {
+    window.sessionStorage.setItem(scopedStorageKey('current-room-code'), 'ROOM01')
+    window.sessionStorage.setItem('currentRoomCode', 'ROOM01')
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true, data: null })),
+    )
+
+    await expect(roomApi.getCurrentRoom()).resolves.toEqual({ success: true, data: null })
+
+    expect(window.sessionStorage.getItem(scopedStorageKey('current-room-code'))).toBeNull()
+    expect(window.sessionStorage.getItem('currentRoomCode')).toBeNull()
+  })
+
+  it('requests room rules with encoded room ids and returns rule data', async () => {
+    const roomRule = {
+      room_id: 'room 01',
+      rule: { name: 'Tiny Demo', player_count: 2 },
+    }
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true, data: roomRule })),
+    )
+
+    await expect(roomApi.getRoomRule('room 01')).resolves.toEqual({
+      success: true,
+      data: roomRule,
+    })
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/room/rule/get?room_id=room%2001'),
+      expect.objectContaining({ method: 'GET' }),
+    )
+  })
 })


### PR DESCRIPTION
## Summary
- Add room API unit coverage for storage cleanup and encoded rule requests.
- Add e2e coverage for create-room and join-room implemented flows.
- Only test files are changed.

## Test Plan
- npm run test:unit -- src/api/__tests__/room.spec.ts
- VITE_ENABLE_TEST_SANDBOX=true npm run build
- npx cypress run --browser electron --config baseUrl=http://127.0.0.1:4873 --spec cypress/e2e/room-flow.cy.ts

Closes #131