### PR TITLE
test: cover creation center behavior

### DIFF
--- a/cypress/e2e/creation-center.cy.ts
+++ b/cypress/e2e/creation-center.cy.ts
@@ -1,0 +1,108 @@
+/// <reference types="cypress" />
+
+const user = {
+  id: 'user-001',
+  username: 'alice',
+  email: 'alice@example.com',
+  avatar: '',
+  token: 'jwt-token',
+}
+
+function navigateInApp(path: string) {
+  cy.window().then((win) => {
+    win.history.pushState({}, '', path)
+    win.dispatchEvent(new win.PopStateEvent('popstate'))
+  })
+  cy.location('pathname').should('eq', path)
+}
+
+function loginAndVisit(path: string) {
+  cy.intercept('POST', '**/api/user/login', {
+    success: true,
+    data: user,
+  }).as('loginForRoute')
+
+  cy.visit('/user-info', { timeout: 60000 })
+  cy.get('input').eq(0).type(user.email)
+  cy.get('input').eq(1).type('password123')
+  cy.contains('button', '登录').click()
+  cy.wait('@loginForRoute')
+  cy.contains('.user-name', user.username).should('be.visible')
+  navigateInApp(path)
+}
+
+describe('创作中心', () => {
+  beforeEach(() => {
+    cy.clearCookies()
+    cy.clearLocalStorage()
+    cy.clearAllSessionStorage()
+  })
+
+  it('展示草稿列表', () => {
+    cy.intercept('GET', '**/api/rules/drafts', {
+      success: true,
+      data: [
+        {
+          id: 'draft 1',
+          name: '单张规则',
+          playerCount: 2,
+          description: '单张出牌流程',
+          status: 'draft',
+          updatedAt: 1700000000000,
+        },
+      ],
+    }).as('listDrafts')
+
+    loginAndVisit('/creation-center')
+    cy.wait('@listDrafts')
+
+    cy.contains('.rule-row', '单张规则').should('be.visible')
+  })
+
+  it('创建新规则会进入规则构建页', () => {
+    cy.intercept('GET', '**/api/rules/drafts', { success: true, data: [] })
+
+    loginAndVisit('/creation-center')
+    cy.contains('button', '创建新规则').click()
+
+    cy.location('pathname').should('eq', '/creation-center/new')
+    cy.contains('h1', '规则构建').should('be.visible')
+  })
+
+  it('确认后删除草稿并从列表移除', () => {
+    cy.intercept('GET', '**/api/rules/drafts', {
+      success: true,
+      data: [
+        {
+          id: 'draft-delete',
+          name: '待删除规则',
+          playerCount: 2,
+          description: 'delete me',
+          status: 'draft',
+          updatedAt: 1700000000000,
+        },
+      ],
+    })
+    cy.intercept('DELETE', '**/api/rules/drafts/draft-delete', {
+      success: true,
+      data: {
+        id: 'draft-delete',
+        name: '待删除规则',
+        playerCount: 2,
+        description: 'delete me',
+        status: 'draft',
+        updatedAt: 1700000000000,
+      },
+    }).as('deleteDraft')
+
+    loginAndVisit('/creation-center')
+    cy.contains('.rule-row', '待删除规则').within(() => {
+      cy.contains('button', '删除').click()
+    })
+    cy.contains('.el-message-box', '删除规则').should('be.visible')
+    cy.get('.el-message-box').contains('button', '删除').click()
+    cy.wait('@deleteDraft')
+
+    cy.contains('.rule-row', '待删除规则').should('not.exist')
+  })
+})

--- a/src/views/__tests__/CreationCenterView.spec.ts
+++ b/src/views/__tests__/CreationCenterView.spec.ts
@@ -1,0 +1,125 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import { ruleApi } from '../../api/rule'
+import { elementPlusStubs } from '../../test-utils/elementPlusStubs'
+import CreationCenterView from '../CreationCenterView.vue'
+
+const push = vi.fn()
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push }),
+}))
+
+vi.mock('../../api/rule', () => ({
+  ruleApi: {
+    listDrafts: vi.fn(),
+    deleteDraft: vi.fn(),
+  },
+}))
+
+vi.mock('element-plus', async () => {
+  const actual = await vi.importActual<typeof import('element-plus')>('element-plus')
+
+  return {
+    ...actual,
+    ElMessage: {
+      success: vi.fn(),
+      error: vi.fn(),
+    },
+    ElMessageBox: {
+      confirm: vi.fn(),
+    },
+  }
+})
+
+const drafts = [
+  {
+    id: 'draft 1',
+    name: 'Rule One',
+    playerCount: 2,
+    description: 'first rule',
+    status: 'draft' as const,
+    updatedAt: 1_700_000_000_000,
+  },
+  {
+    id: 'draft-2',
+    name: 'Rule Two',
+    playerCount: 4,
+    description: '',
+    status: 'published' as const,
+    updatedAt: 1_700_100_000_000,
+  },
+]
+
+describe('CreationCenterView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows the empty state and navigates to a new draft', async () => {
+    vi.mocked(ruleApi.listDrafts).mockResolvedValue({ success: true, data: [] })
+
+    const wrapper = mount(CreationCenterView, {
+      global: { stubs: elementPlusStubs },
+    })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('暂无规则')
+
+    const createButton = wrapper.findAll('button').find(button => button.text().includes('创建新规则'))
+    await createButton?.trigger('click')
+
+    expect(push).toHaveBeenCalledWith('/creation-center/new')
+  })
+
+  it('renders draft rows and opens the selected draft', async () => {
+    vi.mocked(ruleApi.listDrafts).mockResolvedValue({ success: true, data: drafts })
+
+    const wrapper = mount(CreationCenterView, {
+      global: { stubs: elementPlusStubs },
+    })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Rule One')
+    expect(wrapper.text()).toContain('Rule Two')
+
+    await wrapper.find('.rule-row').trigger('click')
+
+    expect(push).toHaveBeenCalledWith('/creation-center/draft%201')
+  })
+
+  it('deletes a confirmed single draft and updates the list', async () => {
+    vi.mocked(ruleApi.listDrafts).mockResolvedValue({ success: true, data: [drafts[0]] })
+    vi.mocked(ElMessageBox.confirm).mockResolvedValue(undefined as never)
+    vi.mocked(ruleApi.deleteDraft).mockResolvedValue({ success: true, data: drafts[0] })
+
+    const wrapper = mount(CreationCenterView, {
+      global: { stubs: elementPlusStubs },
+    })
+    await flushPromises()
+
+    await wrapper.find('.delete-action').trigger('click')
+    await flushPromises()
+
+    expect(ElMessageBox.confirm).toHaveBeenCalledWith(
+      '确定要删除规则“Rule One”吗？删除后无法恢复。',
+      '删除规则',
+      expect.any(Object),
+    )
+    expect(ruleApi.deleteDraft).toHaveBeenCalledWith('draft 1')
+    expect(wrapper.find('.rule-row').exists()).toBe(false)
+    expect(ElMessage.success).toHaveBeenCalledWith('规则已删除')
+  })
+
+  it('shows an error when drafts fail to load', async () => {
+    vi.mocked(ruleApi.listDrafts).mockResolvedValue({ success: false, message: '规则列表不可用' })
+
+    mount(CreationCenterView, {
+      global: { stubs: elementPlusStubs },
+    })
+    await flushPromises()
+
+    expect(ElMessage.error).toHaveBeenCalledWith('规则列表不可用')
+  })
+})


### PR DESCRIPTION
## Summary
- Add creation center unit coverage for empty, list, delete, and error states.
- Add e2e coverage for draft display, new-rule navigation, and confirmed deletion.
- Only test files are changed.

## Test Plan
- npm run test:unit -- src/views/__tests__/CreationCenterView.spec.ts
- VITE_ENABLE_TEST_SANDBOX=true npm run build
- npx cypress run --browser electron --config baseUrl=http://127.0.0.1:4873 --spec cypress/e2e/creation-center.cy.ts

Closes #133