### PR TITLE
test: cover card style persistence

### DIFF
--- a/cypress/e2e/card-style.cy.ts
+++ b/cypress/e2e/card-style.cy.ts
@@ -1,0 +1,94 @@
+/// <reference types="cypress" />
+
+const user = {
+  id: 'user-001',
+  username: 'alice',
+  email: 'alice@example.com',
+  avatar: '',
+  token: 'jwt-token',
+}
+
+function navigateInApp(path: string) {
+  cy.window().then((win) => {
+    win.history.pushState({}, '', path)
+    win.dispatchEvent(new win.PopStateEvent('popstate'))
+  })
+  cy.location('pathname').should('eq', path)
+}
+
+function loginAndVisit(path: string) {
+  cy.intercept('POST', '**/api/user/login', {
+    success: true,
+    data: user,
+  }).as('loginForRoute')
+
+  cy.visit('/user-info', { timeout: 60000 })
+  cy.get('input').eq(0).type(user.email)
+  cy.get('input').eq(1).type('password123')
+  cy.contains('button', '登录').click()
+  cy.wait('@loginForRoute')
+  cy.contains('.user-name', user.username).should('be.visible')
+  navigateInApp(path)
+}
+
+describe('卡牌样式设置', () => {
+  beforeEach(() => {
+    cy.clearCookies()
+    cy.clearLocalStorage()
+    cy.clearAllSessionStorage()
+  })
+
+  it('保存样式设置并在重新进入页面后恢复', () => {
+    loginAndVisit('/card-style')
+
+    cy.contains('h2', '卡牌样式设置').should('be.visible')
+    cy.get('select').eq(0).select('Times New Roman')
+    cy.get('select').eq(1).select('柔和蓝紫')
+    cy.get('input').eq(0).clear().type('https://example.test/front.png')
+    cy.get('input').eq(1).clear().type('https://example.test/back.png')
+
+    cy.window().then((win) => {
+      expect(JSON.parse(win.localStorage.getItem('wildcard-card-style') || '{}')).to.deep.equal({
+        fontFamily: "'Times New Roman', serif",
+        theme: 'soft',
+        frontImage: 'https://example.test/front.png',
+        backImage: 'https://example.test/back.png',
+      })
+    })
+
+    navigateInApp('/user-info')
+    navigateInApp('/card-style')
+    cy.get('select').eq(0).should('have.value', "'Times New Roman', serif")
+    cy.get('select').eq(1).should('have.value', 'soft')
+    cy.get('input').eq(0).should('have.value', 'https://example.test/front.png')
+    cy.get('input').eq(1).should('have.value', 'https://example.test/back.png')
+  })
+
+  it('可以从已保存样式恢复默认样式', () => {
+    loginAndVisit('/card-style')
+    cy.window().then((win) => {
+      win.localStorage.setItem('wildcard-card-style', JSON.stringify({
+        fontFamily: "'Courier New', monospace",
+        theme: 'green',
+        frontImage: 'https://example.test/front.png',
+        backImage: 'https://example.test/back.png',
+      }))
+    })
+    navigateInApp('/user-info')
+    navigateInApp('/card-style')
+
+    cy.get('select').eq(1).should('have.value', 'green')
+    cy.get('.plain-btn').click()
+
+    cy.get('select').eq(0).should('have.value', 'Arial, sans-serif')
+    cy.get('select').eq(1).should('have.value', 'classic')
+    cy.window().then((win) => {
+      expect(JSON.parse(win.localStorage.getItem('wildcard-card-style') || '{}')).to.deep.equal({
+        fontFamily: 'Arial, sans-serif',
+        theme: 'classic',
+        frontImage: '',
+        backImage: '',
+      })
+    })
+  })
+})

--- a/src/views/__tests__/CardStyleView.spec.ts
+++ b/src/views/__tests__/CardStyleView.spec.ts
@@ -1,0 +1,82 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it } from 'vitest'
+import CardStyleView from '../CardStyleView.vue'
+
+const storageKey = 'wildcard-card-style'
+
+describe('CardStyleView', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('renders the default card style when no saved style exists', () => {
+    const wrapper = mount(CardStyleView)
+    const selects = wrapper.findAll('select')
+    const inputs = wrapper.findAll('input')
+
+    expect(selects[0].element.value).toBe('Arial, sans-serif')
+    expect(selects[1].element.value).toBe('classic')
+    expect(inputs[0].element.value).toBe('')
+    expect(inputs[1].element.value).toBe('')
+    expect(wrapper.find('.front-card').classes()).toContain('theme-classic')
+  })
+
+  it('loads a saved card style from localStorage', () => {
+    window.localStorage.setItem(storageKey, JSON.stringify({
+      fontFamily: `'Courier New', monospace`,
+      theme: 'green',
+      frontImage: 'https://example.test/front.png',
+      backImage: 'https://example.test/back.png',
+    }))
+
+    const wrapper = mount(CardStyleView)
+    const selects = wrapper.findAll('select')
+    const inputs = wrapper.findAll('input')
+
+    expect(selects[0].element.value).toBe(`'Courier New', monospace`)
+    expect(selects[1].element.value).toBe('green')
+    expect(inputs[0].element.value).toBe('https://example.test/front.png')
+    expect(inputs[1].element.value).toBe('https://example.test/back.png')
+    expect(wrapper.find('.front-card').classes()).toContain('theme-green')
+  })
+
+  it('persists changed controls to localStorage', async () => {
+    const wrapper = mount(CardStyleView)
+    const selects = wrapper.findAll('select')
+    const inputs = wrapper.findAll('input')
+
+    await selects[0].setValue(`'Times New Roman', serif`)
+    await selects[1].setValue('soft')
+    await inputs[0].setValue('https://example.test/front.jpg')
+    await inputs[1].setValue('https://example.test/back.jpg')
+
+    expect(JSON.parse(window.localStorage.getItem(storageKey) || '{}')).toEqual({
+      fontFamily: `'Times New Roman', serif`,
+      theme: 'soft',
+      frontImage: 'https://example.test/front.jpg',
+      backImage: 'https://example.test/back.jpg',
+    })
+  })
+
+  it('resets the saved style back to defaults', async () => {
+    window.localStorage.setItem(storageKey, JSON.stringify({
+      fontFamily: `'Courier New', monospace`,
+      theme: 'green',
+      frontImage: 'https://example.test/front.png',
+      backImage: 'https://example.test/back.png',
+    }))
+
+    const wrapper = mount(CardStyleView)
+
+    await wrapper.find('.plain-btn').trigger('click')
+
+    expect(JSON.parse(window.localStorage.getItem(storageKey) || '{}')).toEqual({
+      fontFamily: 'Arial, sans-serif',
+      theme: 'classic',
+      frontImage: '',
+      backImage: '',
+    })
+    expect(wrapper.findAll('select')[1].element.value).toBe('classic')
+    expect(wrapper.findAll('input')[0].element.value).toBe('')
+  })
+})


### PR DESCRIPTION
## Summary
- Add card style unit coverage for defaults, loading, persistence, and reset.
- Add e2e coverage for saving, restoring, and resetting saved style settings.
- Only test files are changed.

## Test Plan
- npm run test:unit -- src/views/__tests__/CardStyleView.spec.ts
- VITE_ENABLE_TEST_SANDBOX=true npm run build
- npx cypress run --browser electron --config baseUrl=http://127.0.0.1:4873 --spec cypress/e2e/card-style.cy.ts

Closes #132