### PR TITLE
test: cover game API normalization and battle flow

### DIFF
--- a/cypress/e2e/battle-flow.cy.ts
+++ b/cypress/e2e/battle-flow.cy.ts
@@ -1,0 +1,107 @@
+/// <reference types="cypress" />
+
+const user = {
+  id: 'user-001',
+  username: 'alice',
+  email: 'alice@example.com',
+  avatar: '',
+  token: 'jwt-token',
+}
+
+function navigateInApp(path: string) {
+  cy.window().then((win) => {
+    win.history.pushState({}, '', path)
+    win.dispatchEvent(new win.PopStateEvent('popstate'))
+  })
+  cy.location('pathname').should('eq', path)
+}
+
+function loginAndVisit(path: string) {
+  cy.intercept('POST', '**/api/user/login', {
+    success: true,
+    data: user,
+  }).as('loginForRoute')
+
+  cy.visit('/user-info', { timeout: 60000 })
+  cy.get('input').eq(0).type(user.email)
+  cy.get('input').eq(1).type('password123')
+  cy.contains('button', '登录').click()
+  cy.wait('@loginForRoute')
+  cy.contains('.user-name', user.username).should('be.visible')
+  navigateInApp(path)
+}
+
+const snapshot = {
+  sessionId: 'session-1',
+  roomCode: 'ROOM42',
+  ruleId: 'rule-1',
+  status: 'playing',
+  currentPlayerId: 'user-001',
+  roundTime: 30,
+  deadlineAt: null,
+  players: [
+    { id: 'user-001', username: 'alice', avatar: '', cardCount: 1, online: true },
+    { id: 'user-002', username: 'bob', avatar: '', cardCount: 2, online: true },
+  ],
+  table: {
+    playedCards: [{ id: 'table-card', properties: { point: 13, suit: 1 }, display: { rank: 'K', suit: 'H' } }],
+    passStreak: 0,
+    lastPlayedBy: 'user-002',
+  },
+  handCards: [
+    { id: 'card-a', properties: { point: 14, suit: 0 }, display: { rank: 'A', suit: 'S' } },
+  ],
+  pendingAction: {
+    actionId: 'action-1',
+    playerId: 'user-001',
+    actionType: 'playCards',
+    canSkip: true,
+  },
+  lastAction: null,
+  winnerIds: [],
+}
+
+describe('战斗页交互', () => {
+  beforeEach(() => {
+    cy.clearCookies()
+    cy.clearLocalStorage()
+    cy.clearAllSessionStorage()
+  })
+
+  it('加载手牌、选择手牌并提交出牌动作', () => {
+    cy.intercept('GET', '**/api/games/current?roomCode=ROOM42', {
+      success: true,
+      data: snapshot,
+    }).as('currentGame')
+    cy.intercept('POST', '**/api/games/session-1/actions/action-1/play-cards', {
+      success: true,
+      data: {
+        ...snapshot,
+        handCards: [],
+        table: {
+          ...snapshot.table,
+          playedCards: snapshot.handCards,
+          lastPlayedBy: 'user-001',
+        },
+        pendingAction: null,
+        lastAction: {
+          playerId: 'user-001',
+          action: 'playCards',
+          cards: snapshot.handCards,
+          message: '打出了 1 张牌',
+          turn: 1,
+        },
+      },
+    }).as('playCards')
+
+    loginAndVisit('/game/ROOM42/battle')
+    cy.wait('@currentGame')
+
+    cy.contains('.turn-text', '轮到你出牌').should('be.visible')
+    cy.contains('.hand-card', 'A').click()
+    cy.get('.hand-card.selected').should('have.length', 1)
+    cy.contains('button', 'PLAY').click()
+    cy.wait('@playCards').its('request.body').should('deep.equal', { cardIds: ['card-a'] })
+    cy.contains('.turn-text', '打出了 1 张牌').should('be.visible')
+  })
+})

--- a/src/api/__tests__/game.spec.ts
+++ b/src/api/__tests__/game.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { USER_STORAGE_KEY } from '../../utils/storageNamespace'
 import { gameApi } from '../game'
+import { roomApi } from '../room'
 
 const originalFetch = globalThis.fetch
 
@@ -112,5 +113,94 @@ describe('gameApi', () => {
         body: JSON.stringify({}),
       }),
     )
+  })
+
+  it('normalizes engine-style game sessions with room metadata', async () => {
+    const engineSession = {
+      id: 'engine-session-1',
+      room_code: 'ROOM01',
+      status: 'playing',
+      players: [
+        { id: 'user-001', properties: { hand_count: 1 } },
+        { id: 'user-002', properties: { hand_count: 2 } },
+      ],
+      table: { player_index: 1 },
+      hands: {
+        'user-001': [{ id: 'card-a', properties: { point: 1, suit: 0 } }],
+        'user-002': [
+          { id: 'card-k', properties: { point: 13, suit: 1 } },
+          { id: 'card-q', properties: { point: 12, suit: 2 } },
+        ],
+      },
+      pending_action: {
+        id: 'action-engine-1',
+        player_id: 'user-002',
+        component_type: 21,
+        timer: 30,
+      },
+      last_successful_play: {
+        player_id: 'user-001',
+        cards: [{ id: 'card-prev', properties: { point: 13, suit: 1 } }],
+      },
+      settlement_results: { 'user-002': 1 },
+      last_action_player_id: 'user-001',
+      last_action_cards: [{ id: 'card-prev', properties: { point: 13, suit: 1 } }],
+      last_action_skipped: false,
+    }
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true, data: engineSession })),
+    )
+    globalThis.fetch = fetchMock
+    vi.spyOn(roomApi, 'getRoomByCode').mockResolvedValue({
+      success: true,
+      data: {
+        id: 'room-1',
+        code: 'ROOM01',
+        hostId: 'user-001',
+        playerCount: 2,
+        roundTime: 60,
+        ruleId: 'rule-engine',
+        ruleName: 'Engine Rule',
+        password: null,
+        players: [
+          { id: 'user-001', username: 'alice', avatar: '/alice.png', isReady: true },
+          { id: 'user-002', username: 'bob', avatar: '/bob.png', isReady: true },
+        ],
+        status: 'playing',
+      },
+    })
+
+    const result = await gameApi.getCurrent('ROOM 01')
+
+    expect(roomApi.getRoomByCode).toHaveBeenCalledWith('ROOM 01')
+    expect(result.success).toBe(true)
+    expect(result.data).toMatchObject({
+      sessionId: 'engine-session-1',
+      roomCode: 'ROOM01',
+      ruleId: 'rule-engine',
+      currentPlayerId: 'user-002',
+      roundTime: 60,
+      players: [
+        { id: 'user-001', username: 'alice', cardCount: 1 },
+        { id: 'user-002', username: 'bob', cardCount: 2, finished: true },
+      ],
+      handCards: [{ id: 'card-a', display: { rank: 'A', suit: 'S' } }],
+      table: {
+        playedCards: [{ id: 'card-prev', display: { rank: 'K', suit: 'H' } }],
+        lastPlayedBy: 'user-001',
+      },
+      pendingAction: {
+        actionId: 'action-engine-1',
+        playerId: 'user-002',
+        actionType: 'playCards',
+        canSkip: true,
+      },
+      lastAction: {
+        playerId: 'user-001',
+        action: 'playCards',
+        cards: [{ id: 'card-prev', display: { rank: 'K', suit: 'H' } }],
+      },
+      winnerIds: ['user-002'],
+    })
   })
 })


### PR DESCRIPTION
## Summary
- Add game API unit coverage for engine-style session normalization.
- Add e2e coverage for loading battle data, selecting a hand card, and submitting play.
- Only test files are changed.

## Test Plan
- npm run test:unit -- src/api/__tests__/game.spec.ts
- VITE_ENABLE_TEST_SANDBOX=true npm run build
- npx cypress run --browser electron --config baseUrl=http://127.0.0.1:4873 --spec cypress/e2e/battle-flow.cy.ts

Closes #130