### PR TITLE
test: cover username login and avatar profile data

### DIFF
--- a/cypress/e2e/username-login.cy.ts
+++ b/cypress/e2e/username-login.cy.ts
@@ -1,0 +1,38 @@
+/// <reference types="cypress" />
+
+describe('用户名登录', () => {
+  beforeEach(() => {
+    cy.clearCookies()
+    cy.clearLocalStorage()
+    cy.clearAllSessionStorage()
+    cy.visit('/user-info', { timeout: 60000 })
+  })
+
+  it('允许在登录账号输入框中使用用户名登录', () => {
+    cy.intercept('POST', '**/api/user/login', (req) => {
+      expect(req.body).to.deep.equal({
+        email: 'alice',
+        password: 'password123',
+      })
+
+      req.reply({
+        success: true,
+        data: {
+          id: 'user-001',
+          username: 'alice',
+          email: 'alice@example.com',
+          avatar: '',
+          token: 'jwt-token',
+        },
+      })
+    }).as('loginByUsername')
+
+    cy.get('input').eq(0).type('alice')
+    cy.get('input').eq(1).type('password123')
+    cy.contains('button', '登录').click()
+
+    cy.wait('@loginByUsername')
+    cy.contains('.user-name', 'alice').should('be.visible')
+    cy.contains('.user-email', 'alice@example.com').should('be.visible')
+  })
+})

--- a/src/api/__tests__/userAvatar.spec.ts
+++ b/src/api/__tests__/userAvatar.spec.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { USER_STORAGE_KEY } from '../../utils/storageNamespace'
+import { userApi } from '../user'
+
+const originalFetch = globalThis.fetch
+
+describe('userApi avatar profile data', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    window.sessionStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    vi.restoreAllMocks()
+  })
+
+  it('stores the avatar URL returned by a login response', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        success: true,
+        data: {
+          id: 'user-001',
+          username: 'alice',
+          email: 'alice@example.com',
+          avatar: '/static/avatars/alice.png',
+          token: 'jwt-token',
+        },
+      })),
+    )
+
+    const result = await userApi.login({ email: 'alice@example.com', password: 'secret' })
+
+    expect(result.success).toBe(true)
+    expect(result.data?.avatar).toBe('/static/avatars/alice.png')
+    expect(JSON.parse(window.sessionStorage.getItem(USER_STORAGE_KEY) || '{}')).toMatchObject({
+      id: 'user-001',
+      username: 'alice',
+      avatar: '/static/avatars/alice.png',
+    })
+  })
+
+  it('refreshes the cached avatar URL from the current-user response', async () => {
+    window.sessionStorage.setItem(USER_STORAGE_KEY, JSON.stringify({
+      id: 'user-001',
+      username: 'alice',
+      email: 'alice@example.com',
+      avatar: '/static/avatars/old.png',
+    }))
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        success: true,
+        data: {
+          id: 'user-001',
+          username: 'alice',
+          email: 'alice@example.com',
+          avatar: '/static/avatars/new.png',
+        },
+      })),
+    )
+
+    const result = await userApi.getCurrentUser()
+
+    expect(result.success).toBe(true)
+    expect(result.data?.avatar).toBe('/static/avatars/new.png')
+    expect(JSON.parse(window.sessionStorage.getItem(USER_STORAGE_KEY) || '{}')).toMatchObject({
+      avatar: '/static/avatars/new.png',
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add a Cypress e2e test for username-based login on the user auth page
- add focused userApi tests for avatar URL preservation from login and current-user profile responses

## Verification
- PASS: npm run test:unit -- src/api/__tests__/userAvatar.spec.ts (2 passing)
- PASS: ./node_modules/.bin/start-server-and-test "npm run build && ./node_modules/.bin/vite preview --host 127.0.0.1 --port 4175 --strictPort" http://127.0.0.1:4175 "./node_modules/.bin/cypress run --browser electron --spec cypress/e2e/username-login.cy.ts --config baseUrl=http://127.0.0.1:4175" (1 passing)

## Notes
- This PR intentionally contains test code only.
- The avatar tests cover the frontend behavior that exists on dev today: backend-provided avatar URLs are stored and refreshed through user profile responses.
- It does not assume a frontend userApi.updateAvatar wrapper or upload UI, because those are not present on dev.
- Full e2e on the repo default port was not used because 4173 is occupied by another project on this shared server; the username login spec was verified on temporary port 4175 and the process exited cleanly.

Closes #142
Closes #143