### PR TITLE
feat(room): explicit public/private radio in create-room form

### DIFF
--- a/src/views/CreateRoomView.vue
+++ b/src/views/CreateRoomView.vue
@@ -30,12 +30,24 @@
         </div>
 
         <div class="form-item">
-          <div class="form-label">房间密码（可选）</div>
+          <div class="form-label">房间可见性</div>
+          <el-radio-group v-model="visibility" class="visibility-group">
+            <el-radio value="public">公开</el-radio>
+            <el-radio value="private">私密</el-radio>
+          </el-radio-group>
+          <div class="form-hint">
+            {{ visibility === 'public' ? '任何人凭房间号都能加入' : '需要正确房间密码才能加入' }}
+          </div>
+        </div>
+
+        <div class="form-item" v-if="visibility === 'private'">
+          <div class="form-label">房间密码</div>
           <el-input
             v-model="roomPassword"
-            placeholder="输入密码，留空则无密码"
+            placeholder="请输入密码"
             class="form-input"
             type="password"
+            show-password
           />
         </div>
 
@@ -54,6 +66,7 @@ import type { GameRuleOption } from '../api/room'
 
 const router = useRouter()
 const roundTime = ref(30)
+const visibility = ref<'public' | 'private'>('public')
 const roomPassword = ref('')
 const ruleOptions = ref<GameRuleOption[]>([])
 const selectedRuleId = ref('')
@@ -79,14 +92,20 @@ async function onCreateRoom() {
     return
   }
 
+  if (visibility.value === 'private' && !roomPassword.value.trim()) {
+    ElMessage.error('私密房间必须设置密码')
+    return
+  }
+
   const result = await roomApi.createRoom({
     ruleId: selectedRuleId.value,
     roundTime: roundTime.value,
-    password: roomPassword.value || undefined,
+    password: visibility.value === 'private' ? roomPassword.value.trim() : undefined,
   })
 
   if (result.success && result.data) {
-    ElMessage.success(`房间创建成功，房间号：${result.data.code}`)
+    const visibilityLabel = result.data.hasPassword ? '私密' : '公开'
+    ElMessage.success(`${visibilityLabel}房间创建成功，房间号：${result.data.code}`)
     router.push(getRoomEntryPath(result.data))
   } else {
     ElMessage.error(result.message || '创建房间失败')
@@ -154,6 +173,17 @@ async function onCreateRoom() {
 
 .form-input {
     width: 100%;
+}
+
+.visibility-group {
+    display: flex;
+    gap: 24px;
+}
+
+.form-hint {
+    font-size: 0.85rem;
+    color: #8a8aa0;
+    margin-top: 8px;
 }
 
 .create-room-btn {

--- a/src/views/JoinRoomView.vue
+++ b/src/views/JoinRoomView.vue
@@ -11,14 +11,17 @@
             class="join-room-input"
             @keyup.enter="onRoomCodeInput"
         />
-        <el-input
-            v-else
-            v-model="roomPassword"
-            placeholder="输入房间密码..."
-            class="join-room-input"
-            type="password"
-            @keyup.enter="onJoin"
-        />
+        <template v-else>
+          <div class="visibility-hint">该房间为<span class="visibility-tag private">私密</span>房间，需要输入密码</div>
+          <el-input
+              v-model="roomPassword"
+              placeholder="输入房间密码..."
+              class="join-room-input"
+              type="password"
+              show-password
+              @keyup.enter="onJoin"
+          />
+        </template>
         <el-button class="join-room-btn" size="medium" @click="showPassword ? onJoin() : onRoomCodeInput()">加入房间</el-button>
       </div>
     </div>
@@ -56,6 +59,7 @@ async function onRoomCodeInput() {
 async function joinRoomWithoutPassword() {
     const result = await roomApi.joinRoom({ code: roomCode.value })
     if (result.success && result.data) {
+        ElMessage.success('已加入公开房间')
         router.push(getRoomEntryPath(result.data))
     } else {
         ElMessage.error(result.message || '加入房间失败')
@@ -141,6 +145,31 @@ async function onJoin() {
 
 .join-room-btn:hover {
   background: #ece6fa;
+}
+
+.visibility-hint {
+    font-size: 0.95rem;
+    color: #555;
+    margin-bottom: 14px;
+    text-align: left;
+}
+
+.visibility-tag {
+    display: inline-block;
+    padding: 2px 10px;
+    border-radius: 4px;
+    margin: 0 6px;
+    font-weight: 500;
+}
+
+.visibility-tag.private {
+    background: #fef2f2;
+    color: #b91c1c;
+}
+
+.visibility-tag.public {
+    background: #f0fdf4;
+    color: #15803d;
 }
 
 </style>

--- a/src/views/__tests__/CreateRoomView.spec.ts
+++ b/src/views/__tests__/CreateRoomView.spec.ts
@@ -74,7 +74,7 @@ describe('CreateRoomView', () => {
       password: undefined,
     })
     expect(push).toHaveBeenCalledWith('/game/ROOM42')
-    expect(ElMessage.success).toHaveBeenCalledWith('房间创建成功，房间号：ROOM42')
+    expect(ElMessage.success).toHaveBeenCalledWith('公开房间创建成功，房间号：ROOM42')
   })
 
   it('shows a validation message when no rule is available', async () => {


### PR DESCRIPTION
飞书任务板 \`recvk46FHksVmk\`。

## 改动
- CreateRoomView 新增"房间可见性"单选(公开/私密),选公开时密码框消失,选私密时密码必填
- JoinRoomView 在 check-password 命中已加密房间时,显式提示"该房间为私密房间"
- 创建/加入成功的 toast 包含 公开/私密 标签

后端无改动:Room.password / has_password 字段语义已足够,本 PR 在前端把这个隐式契约显示化。

## 验证
- npm run build 通过
- npm run test:unit 90/90
- 即将部署到生产服务器 81.70.231.146,公网在 http://isetwildcard.me/ 验证

Closes #147