### PR TITLE
feat: hillary 规则市场页面 + 测试断言修正 (替代 #146)

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,10 +1,12 @@
 export { userApi } from './user'
 export { ruleApi } from './rule'
+export { marketApi } from './market'
 export { roomApi } from './room'
 export { gameApi } from './game'
 export { API_CONFIG, getApiUrl } from './config'
 export { apiRequest, apiGet, apiPost, apiPut, apiDelete } from './request'
 
 export type { User, LoginParams, RegisterParams, UpdatePasswordParams } from './user'
+export type { PublishedRuleSummary, PublishedRuleDetail, MarketDeveloper, RuleReview, RuleRoom } from './market'
 export type { Room, Player, CreateRoomParams, JoinRoomParams, GameRuleOption } from './room'
 export type { GameSnapshot, GameCard, GamePlayerView, GameTableView } from './game'

--- a/src/api/market.ts
+++ b/src/api/market.ts
@@ -1,0 +1,227 @@
+import { apiGet, apiPost } from './request'
+import defaultAvatarUrl from '../assets/default-avatar.svg'
+
+export interface MarketDeveloper {
+  id: string
+  name: string
+  avatar: string
+  bio?: string
+}
+
+export interface PublishedRuleSummary {
+  id: string
+  name: string
+  description: string
+  type: string
+  developer: MarketDeveloper
+  rating: number
+  reviewCount: number
+  publishedAt: number
+  coverUrl?: string
+}
+
+export interface RuleReview {
+  id: string
+  authorName: string
+  authorAvatar: string
+  rating: number
+  content: string
+  imageUrl?: string
+  createdAt: number
+}
+
+export interface PublishedRuleDetail extends PublishedRuleSummary {
+  introduction: string
+  screenshots: string[]
+  reviews: RuleReview[]
+}
+
+export interface RuleRoom {
+  id: string
+  code: string
+  hostName: string
+  currentPlayers: number
+  maxPlayers: number
+  hasPassword: boolean
+  status: 'waiting' | 'playing'
+}
+
+interface ApiResult<T = unknown> {
+  success: boolean
+  data?: T
+  message?: string
+}
+
+interface RuleQueryParams {
+  keyword?: string
+  type?: string
+}
+
+interface ReviewPayload {
+  rating: number
+  content: string
+  imageUrl?: string
+}
+
+const useMarketMock = import.meta.env.VITE_RULE_MARKET_USE_MOCK !== 'false'
+
+const mockDeveloper: MarketDeveloper = {
+  id: 'dev-demo',
+  name: 'WildCard Studio',
+  avatar: defaultAvatarUrl,
+  bio: '专注于轻量桌游规则和快速联机体验。',
+}
+
+const mockRules: PublishedRuleDetail[] = [
+  {
+    id: 'builtin-test2-rule',
+    name: 'Tiny Demo',
+    description: '双人快速对局规则，适合测试出牌、结算和房间流程。',
+    type: '对战',
+    developer: mockDeveloper,
+    rating: 4.6,
+    reviewCount: 18,
+    publishedAt: Date.now() - 1000 * 60 * 60 * 24 * 3,
+    coverUrl: '',
+    screenshots: [],
+    introduction: 'Tiny Demo 是一套短局制规则，强调快速发牌、即时比较和明确结算。它适合作为新玩家熟悉 WildCard 自定义规则流程的入门模板。',
+    reviews: [
+      {
+        id: 'review-1',
+        authorName: '测试玩家',
+        authorAvatar: defaultAvatarUrl,
+        rating: 5,
+        content: '节奏很快，适合用来验证房间和对局流程。',
+        createdAt: Date.now() - 1000 * 60 * 60 * 12,
+      },
+    ],
+  },
+  {
+    id: 'builtin-test-rule',
+    name: 'Duel Demo',
+    description: '面向双人博弈的经典示例规则，包含更完整的胜负判断。',
+    type: '策略',
+    developer: {
+      id: 'dev-rule-lab',
+      name: 'Rule Lab',
+      avatar: defaultAvatarUrl,
+      bio: '探索可视化规则构建的更多可能。',
+    },
+    rating: 4.3,
+    reviewCount: 11,
+    publishedAt: Date.now() - 1000 * 60 * 60 * 24 * 8,
+    coverUrl: '',
+    screenshots: [],
+    introduction: 'Duel Demo 保留了双人对抗的核心结构，并用更完整的流程演示规则构建器导出的运行逻辑。',
+    reviews: [],
+  },
+]
+
+function filterRules(rules: PublishedRuleSummary[], params: RuleQueryParams = {}) {
+  const keyword = params.keyword?.trim().toLowerCase()
+  return rules.filter((rule) => {
+    const matchesKeyword = !keyword
+      || rule.name.toLowerCase().includes(keyword)
+      || rule.developer.name.toLowerCase().includes(keyword)
+    const matchesType = !params.type || rule.type === params.type
+    return matchesKeyword && matchesType
+  })
+}
+
+function buildQuery(params: RuleQueryParams = {}) {
+  const searchParams = new URLSearchParams()
+  if (params.keyword) {
+    searchParams.set('keyword', params.keyword)
+  }
+  if (params.type) {
+    searchParams.set('type', params.type)
+  }
+  const query = searchParams.toString()
+  return query ? `?${query}` : ''
+}
+
+export const marketApi = {
+  async listPublishedRules(params: RuleQueryParams = {}): Promise<ApiResult<PublishedRuleSummary[]>> {
+    return apiGet<ApiResult<PublishedRuleSummary[]>>(`/api/rules/published${buildQuery(params)}`, {
+      useMock: useMarketMock,
+      mockFn: () => ({ success: true, data: filterRules(mockRules, params) }),
+    })
+  },
+
+  async getPublishedRuleDetail(ruleId: string): Promise<ApiResult<PublishedRuleDetail>> {
+    return apiGet<ApiResult<PublishedRuleDetail>>(`/api/rules/published/${encodeURIComponent(ruleId)}`, {
+      useMock: useMarketMock,
+      mockFn: () => ({
+        success: true,
+        data: mockRules.find((rule) => rule.id === ruleId) || mockRules[0],
+      }),
+    })
+  },
+
+  async listDeveloperRules(developerId: string, params: Pick<RuleQueryParams, 'keyword'> = {}): Promise<ApiResult<PublishedRuleSummary[]>> {
+    return apiGet<ApiResult<PublishedRuleSummary[]>>(
+      `/api/rules/developers/${encodeURIComponent(developerId)}/rules${buildQuery(params)}`,
+      {
+        useMock: useMarketMock,
+        mockFn: () => ({
+          success: true,
+          data: filterRules(
+            mockRules.filter((rule) => rule.developer.id === developerId),
+            params,
+          ),
+        }),
+      },
+    )
+  },
+
+  async listRuleRooms(ruleId: string): Promise<ApiResult<RuleRoom[]>> {
+    return apiGet<ApiResult<RuleRoom[]>>(`/api/rules/published/${encodeURIComponent(ruleId)}/rooms`, {
+      useMock: useMarketMock,
+      mockFn: () => ({
+        success: true,
+        data: [
+          {
+            id: 'room-demo-1',
+            code: 'A1B2C3',
+            hostName: '房主A',
+            currentPlayers: 1,
+            maxPlayers: 2,
+            hasPassword: false,
+            status: 'waiting',
+          },
+          {
+            id: 'room-demo-2',
+            code: 'D4E5F6',
+            hostName: '房主B',
+            currentPlayers: 2,
+            maxPlayers: 2,
+            hasPassword: true,
+            status: 'playing',
+          },
+        ],
+      }),
+    })
+  },
+
+  async postRuleReview(ruleId: string, payload: ReviewPayload): Promise<ApiResult<RuleReview>> {
+    return apiPost<ApiResult<RuleReview>>(
+      `/api/rules/published/${encodeURIComponent(ruleId)}/reviews`,
+      payload,
+      {
+        useMock: useMarketMock,
+        mockFn: () => ({
+          success: true,
+          data: {
+            id: `review-${Date.now()}`,
+            authorName: '我',
+            authorAvatar: defaultAvatarUrl,
+            rating: payload.rating,
+            content: payload.content,
+            imageUrl: payload.imageUrl,
+            createdAt: Date.now(),
+          },
+        }),
+      },
+    )
+  },
+}

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -19,6 +19,10 @@
             <el-icon><EditPen /></el-icon>
             <span>创作中心</span>
           </router-link>
+          <router-link to="/rule-market" class="nav-item" exact-active-class="active">
+            <el-icon><Shop /></el-icon>
+            <span>规则市场</span>
+          </router-link>
           <router-link to="/user-info" class="nav-item" exact-active-class="active">
             <el-icon><User /></el-icon>
             <span>用户中心</span>

--- a/src/layouts/__tests__/MainLayout.spec.ts
+++ b/src/layouts/__tests__/MainLayout.spec.ts
@@ -53,7 +53,7 @@ describe('MainLayout', () => {
       expect(wrapper.text()).toContain('首页')
       expect(wrapper.text()).toContain('创作中心')
       expect(wrapper.text()).toContain('用户中心')
-      expect(wrapper.text()).not.toContain('规则市场')
+      expect(wrapper.text()).toContain('规则市场')
       expect(wrapper.text()).not.toContain('卡牌样式')
       expect(wrapper.text()).not.toContain('对局界面')
     })

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -12,6 +12,10 @@ import JoinRoomView from '../views/JoinRoomView.vue'
 import CreateRoomView from '../views/CreateRoomView.vue'
 import CreationCenterView from '../views/CreationCenterView.vue'
 import RuleBuilderView from '../views/RuleBuilderView.vue'
+import RuleMarketHomeView from '../views/RuleMarketHomeView.vue'
+import RuleMarketDetailView from '../views/RuleMarketDetailView.vue'
+import RuleDeveloperDetailView from '../views/RuleDeveloperDetailView.vue'
+import RuleRoomSearchView from '../views/RuleRoomSearchView.vue'
 import { roomApi, getRoomEntryPath } from '../api/room'
 import { useUserStore } from '../stores/userStore'
 
@@ -27,7 +31,19 @@ const routes: RouteRecordRaw[] = [
       },
       {
         path: 'rule-market',
-        component: { template: '<div>规则市场</div>' }
+        component: RuleMarketHomeView
+      },
+      {
+        path: 'rule-market/developer/:developerId',
+        component: RuleDeveloperDetailView
+      },
+      {
+        path: 'rule-market/:ruleId/rooms',
+        component: RuleRoomSearchView
+      },
+      {
+        path: 'rule-market/:ruleId',
+        component: RuleMarketDetailView
       },
       {
         path: 'card-style',

--- a/src/views/CreateRoomView.vue
+++ b/src/views/CreateRoomView.vue
@@ -59,11 +59,12 @@
 
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { ElMessage } from 'element-plus'
 import { roomApi, getRoomEntryPath } from '../api/room'
 import type { GameRuleOption } from '../api/room'
 
+const route = useRoute()
 const router = useRouter()
 const roundTime = ref(30)
 const visibility = ref<'public' | 'private'>('public')
@@ -79,12 +80,36 @@ onMounted(async () => {
 
   if (result.success && result.data && result.data.length > 0) {
     ruleOptions.value = result.data
-    selectedRuleId.value = result.data[0].id
+    applyRouteRuleSelection(result.data)
     return
   }
 
   ElMessage.error(result.message || '游戏规则加载失败')
 })
+
+function applyRouteRuleSelection(options: GameRuleOption[]) {
+  const routeRuleId = typeof route.query.ruleId === 'string' ? route.query.ruleId : ''
+  const routeRuleName = typeof route.query.ruleName === 'string' ? route.query.ruleName : '市场规则'
+
+  if (!routeRuleId) {
+    selectedRuleId.value = options[0]?.id || ''
+    return
+  }
+
+  if (!options.some((rule) => rule.id === routeRuleId)) {
+    ruleOptions.value = [
+      {
+        id: routeRuleId,
+        name: routeRuleName,
+        playerCount: 2,
+        description: '从规则市场快速使用的规则',
+      },
+      ...options,
+    ]
+  }
+
+  selectedRuleId.value = routeRuleId
+}
 
 async function onCreateRoom() {
   if (!selectedRuleId.value) {

--- a/src/views/JoinRoomView.vue
+++ b/src/views/JoinRoomView.vue
@@ -29,15 +29,23 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
-import { useRouter } from 'vue-router'
+import { onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { ElMessage } from 'element-plus'
 import { roomApi, getRoomEntryPath } from '../api/room'
 
+const route = useRoute()
 const router = useRouter()
 const roomCode = ref('')
 const roomPassword = ref('')
 const showPassword = ref(false)
+
+onMounted(() => {
+    const queryCode = typeof route.query.code === 'string' ? route.query.code : ''
+    if (queryCode) {
+        roomCode.value = queryCode
+    }
+})
 
 async function onRoomCodeInput() {
     if (!roomCode.value) {

--- a/src/views/RuleDeveloperDetailView.vue
+++ b/src/views/RuleDeveloperDetailView.vue
@@ -1,0 +1,215 @@
+<template>
+  <div class="developer-page">
+    <header class="developer-header">
+      <img :src="developerAvatar" :alt="developerName">
+      <div>
+        <h1>{{ developerName }}</h1>
+        <p>{{ developerBio }}</p>
+      </div>
+    </header>
+
+    <section class="search-panel">
+      <el-input
+        v-model="keyword"
+        placeholder="搜索该开发者发布的规则"
+        clearable
+        @keyup.enter="loadRules"
+        @clear="loadRules"
+      >
+        <template #prefix>
+          <el-icon><Search /></el-icon>
+        </template>
+      </el-input>
+      <el-button class="market-btn" @click="loadRules">搜索</el-button>
+    </section>
+
+    <el-skeleton v-if="loading" :rows="6" animated class="panel" />
+    <el-empty v-else-if="rules.length === 0" description="暂无规则" />
+    <main v-else class="rule-list">
+      <article
+        v-for="rule in rules"
+        :key="rule.id"
+        class="rule-row"
+        role="button"
+        tabindex="0"
+        @click="openRule(rule.id)"
+        @keydown.enter.prevent="openRule(rule.id)"
+      >
+        <div>
+          <h2>{{ rule.name }}</h2>
+          <p>{{ rule.description }}</p>
+        </div>
+        <div class="rule-meta">
+          <el-tag size="small">{{ rule.type }}</el-tag>
+          <el-rate :model-value="rule.rating" disabled allow-half size="small" />
+          <span>{{ rule.rating.toFixed(1) }} 分</span>
+        </div>
+      </article>
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { ElMessage } from 'element-plus'
+import defaultAvatarUrl from '../assets/default-avatar.svg'
+import { marketApi, type PublishedRuleSummary } from '../api/market'
+
+const route = useRoute()
+const router = useRouter()
+const loading = ref(false)
+const keyword = ref('')
+const rules = ref<PublishedRuleSummary[]>([])
+
+const developerId = computed(() => String(route.params.developerId || ''))
+const firstRule = computed(() => rules.value[0])
+const developerName = computed(() => firstRule.value?.developer.name || '开发者')
+const developerAvatar = computed(() => firstRule.value?.developer.avatar || defaultAvatarUrl)
+const developerBio = computed(() => firstRule.value?.developer.bio || '该开发者还没有留下简介。')
+
+async function loadRules() {
+  loading.value = true
+  const result = await marketApi.listDeveloperRules(developerId.value, { keyword: keyword.value })
+  loading.value = false
+
+  if (!result.success) {
+    ElMessage.error(result.message || '开发者规则加载失败')
+    return
+  }
+
+  rules.value = result.data || []
+}
+
+function openRule(ruleId: string) {
+  void router.push(`/rule-market/${encodeURIComponent(ruleId)}`)
+}
+
+onMounted(() => {
+  void loadRules()
+})
+</script>
+
+<style scoped>
+.developer-page {
+  min-height: 100%;
+  padding: 28px;
+  background: #f5f6fa;
+  color: #252633;
+  text-align: left;
+}
+
+.developer-header,
+.search-panel,
+.rule-row,
+.panel {
+  border: 1px solid #dfe3ec;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.developer-header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 22px 24px;
+  margin-bottom: 16px;
+}
+
+.developer-header img {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.developer-header h1 {
+  margin: 0;
+  font-size: 26px;
+  letter-spacing: 0;
+}
+
+.developer-header p {
+  margin-top: 6px;
+  color: #687083;
+}
+
+.search-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  padding: 16px;
+  margin-bottom: 16px;
+}
+
+.panel {
+  padding: 24px;
+}
+
+.rule-list {
+  display: grid;
+  gap: 12px;
+}
+
+.rule-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 16px;
+  align-items: center;
+  padding: 18px 20px;
+  cursor: pointer;
+}
+
+.rule-row:hover {
+  border-color: #7b8cff;
+  box-shadow: 0 8px 22px rgba(42, 55, 120, 0.08);
+}
+
+.rule-row h2 {
+  margin: 0;
+  font-size: 18px;
+  letter-spacing: 0;
+}
+
+.rule-row p {
+  margin-top: 6px;
+  color: #687083;
+  line-height: 1.55;
+}
+
+.rule-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: #687083;
+  font-size: 13px;
+}
+
+.market-btn {
+  min-width: 96px;
+  padding: 10px 22px;
+  border: 2px solid #222;
+  border-radius: 10px;
+  background: #fff;
+  color: #222;
+  font-weight: 600;
+}
+
+.market-btn:hover,
+.market-btn:focus {
+  border-color: #222;
+  background: #ece6fa;
+  color: #222;
+}
+
+@media (max-width: 760px) {
+  .search-panel,
+  .rule-row {
+    grid-template-columns: 1fr;
+  }
+
+  .rule-meta {
+    flex-wrap: wrap;
+  }
+}
+</style>

--- a/src/views/RuleMarketDetailView.vue
+++ b/src/views/RuleMarketDetailView.vue
@@ -1,0 +1,415 @@
+<template>
+  <div class="detail-page">
+    <el-skeleton v-if="loading" :rows="8" animated class="panel" />
+    <template v-else-if="rule">
+      <header class="detail-header">
+        <div>
+          <div class="title-line">
+            <h1>{{ rule.name }}</h1>
+            <el-tag>{{ rule.type }}</el-tag>
+          </div>
+          <div class="rating-line">
+            <el-rate :model-value="rule.rating" disabled allow-half />
+            <span>{{ rule.rating.toFixed(1) }} 分 · {{ rule.reviewCount }} 条评价</span>
+          </div>
+        </div>
+        <button type="button" class="developer-card" @click="openDeveloper">
+          <img :src="rule.developer.avatar" :alt="rule.developer.name">
+          <strong>{{ rule.developer.name }}</strong>
+        </button>
+      </header>
+
+      <main class="detail-grid">
+        <section class="screenshot-panel panel">
+          <img v-if="activeScreenshot" :src="activeScreenshot" :alt="rule.name">
+          <div v-else class="screenshot-placeholder">{{ rule.type }}</div>
+        </section>
+        <section class="intro-panel panel">
+          <h2>玩法介绍</h2>
+          <p>{{ rule.introduction || rule.description }}</p>
+          <div class="action-row">
+            <el-button class="market-btn" @click="router.push(`/rule-market/${encodeURIComponent(rule.id)}/rooms`)">搜索房间</el-button>
+            <el-button class="market-btn" @click="quickCreateRoom">快速使用规则</el-button>
+          </div>
+        </section>
+      </main>
+
+      <section class="review-panel panel">
+        <h2>评分与评论</h2>
+        <div class="review-form">
+          <el-rate v-model="reviewRating" />
+          <el-input v-model="reviewContent" type="textarea" :rows="3" placeholder="写下你的体验" />
+          <div class="upload-row">
+            <el-upload
+              :auto-upload="false"
+              :limit="1"
+              accept="image/*"
+              :show-file-list="false"
+              :on-change="handleImageChange"
+              :on-remove="clearReviewImage"
+            >
+              <el-button class="market-btn">上传图片</el-button>
+            </el-upload>
+            <span v-if="reviewImageName" class="upload-name">{{ reviewImageName }}</span>
+            <el-button v-if="reviewImageUrl" class="text-btn" @click="clearReviewImage">移除</el-button>
+            <el-button class="market-btn submit-btn" :loading="submitting" @click="submitReview">提交评论</el-button>
+          </div>
+          <img v-if="reviewImageUrl" :src="reviewImageUrl" alt="评论图片预览" class="upload-preview">
+        </div>
+        <el-empty v-if="rule.reviews.length === 0" description="暂无评论" />
+        <article v-for="review in rule.reviews" v-else :key="review.id" class="review-item">
+          <img :src="review.authorAvatar" :alt="review.authorName" class="review-avatar">
+          <div>
+            <div class="review-meta">
+              <strong>{{ review.authorName }}</strong>
+              <el-rate :model-value="review.rating" disabled size="small" />
+              <span>{{ formatDate(review.createdAt) }}</span>
+            </div>
+            <p>{{ review.content }}</p>
+            <img v-if="review.imageUrl" :src="review.imageUrl" :alt="review.content" class="review-image">
+          </div>
+        </article>
+      </section>
+    </template>
+    <el-empty v-else description="规则不存在" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { ElMessage } from 'element-plus'
+import type { UploadFile } from 'element-plus'
+import { marketApi, type PublishedRuleDetail } from '../api/market'
+
+const route = useRoute()
+const router = useRouter()
+const loading = ref(false)
+const submitting = ref(false)
+const rule = ref<PublishedRuleDetail | null>(null)
+const reviewRating = ref(5)
+const reviewContent = ref('')
+const reviewImageUrl = ref('')
+const reviewImageName = ref('')
+
+const ruleId = computed(() => String(route.params.ruleId || ''))
+const activeScreenshot = computed(() => rule.value?.screenshots[0] || rule.value?.coverUrl || '')
+
+function formatDate(timestamp: number) {
+  return new Date(timestamp).toLocaleString('zh-CN', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+async function loadRule() {
+  loading.value = true
+  const result = await marketApi.getPublishedRuleDetail(ruleId.value)
+  loading.value = false
+
+  if (!result.success) {
+    ElMessage.error(result.message || '规则详情加载失败')
+    return
+  }
+
+  rule.value = result.data || null
+}
+
+function openDeveloper() {
+  if (!rule.value) {
+    return
+  }
+  void router.push(`/rule-market/developer/${encodeURIComponent(rule.value.developer.id)}`)
+}
+
+function quickCreateRoom() {
+  if (!rule.value) {
+    return
+  }
+  void router.push({
+    path: '/create-room',
+    query: {
+      ruleId: rule.value.id,
+      ruleName: rule.value.name,
+    },
+  })
+}
+
+async function submitReview() {
+  if (!rule.value || !reviewContent.value.trim()) {
+    ElMessage.warning('请填写评论内容')
+    return
+  }
+
+  submitting.value = true
+  const result = await marketApi.postRuleReview(rule.value.id, {
+    rating: reviewRating.value,
+    content: reviewContent.value.trim(),
+    imageUrl: reviewImageUrl.value.trim() || undefined,
+  })
+  submitting.value = false
+
+  if (!result.success || !result.data) {
+    ElMessage.error(result.message || '评论提交失败')
+    return
+  }
+
+  rule.value.reviews = [result.data, ...rule.value.reviews]
+  reviewContent.value = ''
+  clearReviewImage()
+  ElMessage.success('评论已提交')
+}
+
+function handleImageChange(file: UploadFile) {
+  const rawFile = file.raw
+  if (!rawFile) {
+    return
+  }
+
+  if (!rawFile.type.startsWith('image/')) {
+    ElMessage.warning('请上传图片文件')
+    return
+  }
+
+  const reader = new FileReader()
+  reader.onload = () => {
+    reviewImageUrl.value = typeof reader.result === 'string' ? reader.result : ''
+    reviewImageName.value = rawFile.name
+  }
+  reader.readAsDataURL(rawFile)
+}
+
+function clearReviewImage() {
+  reviewImageUrl.value = ''
+  reviewImageName.value = ''
+}
+
+onMounted(() => {
+  void loadRule()
+})
+</script>
+
+<style scoped>
+.detail-page {
+  min-height: 100%;
+  padding: 28px;
+  background: #f5f6fa;
+  color: #252633;
+  text-align: left;
+}
+
+.panel,
+.detail-header {
+  border: 1px solid #dfe3ec;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 22px 24px;
+  margin-bottom: 16px;
+}
+
+.title-line,
+.rating-line,
+.action-row,
+.review-meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.title-line h1 {
+  margin: 0;
+  font-size: 26px;
+  letter-spacing: 0;
+}
+
+.rating-line {
+  margin-top: 8px;
+  color: #687083;
+}
+
+.developer-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 220px;
+  padding: 12px;
+  border: 1px solid #dfe3ec;
+  border-radius: 8px;
+  background: #fbfcfe;
+  color: #252633;
+  text-align: left;
+  cursor: pointer;
+}
+
+.developer-card img,
+.review-avatar {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.screenshot-panel {
+  min-height: 320px;
+  overflow: hidden;
+}
+
+.screenshot-panel img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.screenshot-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  min-height: 320px;
+  background: #eef1f7;
+  color: #4f5665;
+  font-size: 28px;
+  font-weight: 700;
+}
+
+.intro-panel,
+.review-panel {
+  padding: 22px;
+}
+
+.intro-panel h2,
+.review-panel h2 {
+  margin: 0 0 14px;
+  font-size: 20px;
+  letter-spacing: 0;
+}
+
+.intro-panel p {
+  color: #687083;
+  line-height: 1.8;
+  margin-bottom: 20px;
+}
+
+.review-form {
+  display: grid;
+  gap: 12px;
+  max-width: 720px;
+  margin-bottom: 18px;
+}
+
+.upload-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.upload-name {
+  color: #687083;
+  font-size: 14px;
+}
+
+.upload-preview {
+  width: 180px;
+  max-height: 120px;
+  border-radius: 8px;
+  border: 1px solid #dfe3ec;
+  object-fit: cover;
+}
+
+.market-btn {
+  min-width: 96px;
+  padding: 10px 22px;
+  border: 2px solid #222;
+  border-radius: 10px;
+  background: #fff;
+  color: #222;
+  font-weight: 600;
+}
+
+.market-btn:hover,
+.market-btn:focus {
+  border-color: #222;
+  background: #ece6fa;
+  color: #222;
+}
+
+.submit-btn {
+  width: fit-content;
+}
+
+.text-btn {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: #b42323;
+}
+
+.text-btn:hover,
+.text-btn:focus {
+  background: transparent;
+  color: #8a1c1c;
+}
+
+.review-item {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 12px;
+  padding: 16px 0;
+  border-top: 1px solid #edf0f5;
+}
+
+.review-meta {
+  color: #687083;
+  font-size: 13px;
+}
+
+.review-meta strong {
+  color: #252633;
+  font-size: 15px;
+}
+
+.review-item p {
+  margin-top: 8px;
+  color: #3c4351;
+  line-height: 1.65;
+}
+
+.review-image {
+  max-width: 240px;
+  max-height: 160px;
+  margin-top: 10px;
+  border-radius: 8px;
+  object-fit: cover;
+}
+
+@media (max-width: 900px) {
+  .detail-header,
+  .detail-grid {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .developer-card {
+    width: 100%;
+  }
+}
+</style>

--- a/src/views/RuleMarketHomeView.vue
+++ b/src/views/RuleMarketHomeView.vue
@@ -1,0 +1,290 @@
+<template>
+  <div class="market-page">
+    <header class="market-header">
+      <div>
+        <h1>规则市场</h1>
+        <p>浏览玩家创建的自定义规则。</p>
+      </div>
+      <el-button class="market-btn" @click="router.push('/creation-center/new')">创建规则</el-button>
+    </header>
+
+    <section class="filter-panel">
+      <el-input
+        v-model="keyword"
+        placeholder="搜索规则名或开发者名字"
+        clearable
+        class="keyword-input"
+        @keyup.enter="loadRules"
+        @clear="loadRules"
+      >
+        <template #prefix>
+          <el-icon><Search /></el-icon>
+        </template>
+      </el-input>
+      <el-select v-model="selectedType" placeholder="规则类型" clearable class="type-select" @change="loadRules">
+        <el-option v-for="type in ruleTypes" :key="type" :label="type" :value="type" />
+      </el-select>
+      <el-button class="market-btn" @click="clearFilters">清空筛选</el-button>
+      <el-button class="market-btn" @click="loadRules">搜索</el-button>
+    </section>
+
+    <el-skeleton v-if="loading" :rows="5" animated class="market-skeleton" />
+    <el-empty v-else-if="rules.length === 0" description="暂无匹配的规则" />
+    <main v-else class="rule-grid">
+      <article
+        v-for="rule in rules"
+        :key="rule.id"
+        class="rule-card"
+        role="button"
+        tabindex="0"
+        @click="openRule(rule.id)"
+        @keydown.enter.prevent="openRule(rule.id)"
+      >
+        <div class="rule-cover">
+          <img v-if="rule.coverUrl" :src="rule.coverUrl" :alt="rule.name">
+          <span v-else>{{ rule.type }}</span>
+        </div>
+        <div class="rule-card-body">
+          <div class="rule-title-row">
+            <h2>{{ rule.name }}</h2>
+            <el-tag size="small">{{ rule.type }}</el-tag>
+          </div>
+          <p>{{ rule.description }}</p>
+          <div class="developer-row">
+            <img :src="rule.developer.avatar" :alt="rule.developer.name">
+            <span>{{ rule.developer.name }}</span>
+          </div>
+          <div class="card-footer">
+            <el-rate :model-value="rule.rating" disabled allow-half size="small" />
+            <span>{{ rule.rating.toFixed(1) }} · {{ rule.reviewCount }} 条评价</span>
+            <span>{{ formatDate(rule.publishedAt) }}</span>
+          </div>
+        </div>
+      </article>
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { ElMessage } from 'element-plus'
+import { marketApi, type PublishedRuleSummary } from '../api/market'
+
+const router = useRouter()
+const loading = ref(false)
+const keyword = ref('')
+const selectedType = ref('')
+const rules = ref<PublishedRuleSummary[]>([])
+
+const ruleTypes = computed(() => Array.from(new Set(rules.value.map((rule) => rule.type))).filter(Boolean))
+
+function formatDate(timestamp: number) {
+  return new Date(timestamp).toLocaleDateString('zh-CN')
+}
+
+async function loadRules() {
+  loading.value = true
+  const result = await marketApi.listPublishedRules({
+    keyword: keyword.value,
+    type: selectedType.value,
+  })
+  loading.value = false
+
+  if (!result.success) {
+    ElMessage.error(result.message || '规则市场加载失败')
+    return
+  }
+
+  rules.value = result.data || []
+}
+
+function clearFilters() {
+  keyword.value = ''
+  selectedType.value = ''
+  void loadRules()
+}
+
+function openRule(ruleId: string) {
+  void router.push(`/rule-market/${encodeURIComponent(ruleId)}`)
+}
+
+onMounted(() => {
+  void loadRules()
+})
+</script>
+
+<style scoped>
+.market-page {
+  min-height: 100%;
+  padding: 28px;
+  background: #f5f6fa;
+  color: #252633;
+  text-align: left;
+}
+
+.market-header,
+.filter-panel,
+.rule-card {
+  border: 1px solid #dfe3ec;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.market-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 22px 24px;
+  margin-bottom: 16px;
+}
+
+.market-header h1 {
+  margin: 0;
+  font-size: 26px;
+  letter-spacing: 0;
+}
+
+.market-header p {
+  margin-top: 6px;
+  color: #687083;
+}
+
+.filter-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 180px auto auto;
+  gap: 12px;
+  align-items: center;
+  padding: 16px;
+  margin-bottom: 16px;
+}
+
+.keyword-input {
+  width: 100%;
+}
+
+.type-select {
+  width: 180px;
+}
+
+.market-btn {
+  min-width: 96px;
+  padding: 10px 22px;
+  border: 2px solid #222;
+  border-radius: 10px;
+  background: #fff;
+  color: #222;
+  font-weight: 600;
+}
+
+.market-btn:hover,
+.market-btn:focus {
+  border-color: #222;
+  background: #ece6fa;
+  color: #222;
+}
+
+.market-skeleton {
+  padding: 24px;
+  border: 1px solid #dfe3ec;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.rule-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 14px;
+}
+
+.rule-card {
+  display: grid;
+  grid-template-rows: 150px minmax(0, 1fr);
+  overflow: hidden;
+  cursor: pointer;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.rule-card:hover {
+  border-color: #7b8cff;
+  box-shadow: 0 8px 22px rgba(42, 55, 120, 0.08);
+}
+
+.rule-cover {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #eef1f7;
+  color: #4f5665;
+  font-weight: 700;
+}
+
+.rule-cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.rule-card-body {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+}
+
+.rule-title-row,
+.developer-row,
+.card-footer {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.rule-title-row {
+  justify-content: space-between;
+}
+
+.rule-title-row h2 {
+  margin: 0;
+  font-size: 18px;
+  letter-spacing: 0;
+}
+
+.rule-card-body p {
+  min-height: 44px;
+  color: #687083;
+  line-height: 1.55;
+}
+
+.developer-row img {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.card-footer {
+  flex-wrap: wrap;
+  color: #687083;
+  font-size: 13px;
+}
+
+@media (max-width: 760px) {
+  .market-page {
+    padding: 18px;
+  }
+
+  .market-header,
+  .filter-panel {
+    align-items: stretch;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .keyword-input,
+  .type-select {
+    width: 100%;
+    max-width: none;
+  }
+}
+</style>

--- a/src/views/RuleRoomSearchView.vue
+++ b/src/views/RuleRoomSearchView.vue
@@ -1,0 +1,237 @@
+<template>
+  <div class="room-search-page">
+    <header class="room-header">
+      <div>
+        <h1>{{ ruleTitle }}</h1>
+        <p>当前在线房间 {{ rooms.length }} 个</p>
+      </div>
+      <el-button class="market-btn" @click="createRoom">快速创建房间</el-button>
+    </header>
+
+    <el-skeleton v-if="loading" :rows="6" animated class="panel" />
+    <el-empty v-else-if="rooms.length === 0" description="暂无正在游玩的房间" />
+    <main v-else class="room-grid">
+      <article v-for="room in rooms" :key="room.id" class="room-card">
+        <div class="room-card-head">
+          <div>
+            <h2>{{ room.code }}</h2>
+            <p>房主：{{ room.hostName }}</p>
+          </div>
+          <el-tag :type="room.status === 'waiting' ? 'primary' : 'info'" size="small">
+            {{ room.status === 'waiting' ? '等待中' : '游戏中' }}
+          </el-tag>
+        </div>
+        <div class="room-info-grid">
+          <div class="room-info-item">
+            <span>人数</span>
+            <strong>{{ room.currentPlayers }} / {{ room.maxPlayers }}</strong>
+          </div>
+          <div class="room-info-item">
+            <span>密码</span>
+            <strong class="password-state">
+              <el-icon>
+                <Lock v-if="room.hasPassword" />
+                <Unlock v-else />
+              </el-icon>
+              {{ room.hasPassword ? '需要' : '无' }}
+            </strong>
+          </div>
+        </div>
+        <el-button class="market-btn join-btn" :disabled="room.status !== 'waiting'" @click="joinRoom(room.code)">加入</el-button>
+      </article>
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { ElMessage } from 'element-plus'
+import { marketApi, type RuleRoom } from '../api/market'
+
+const route = useRoute()
+const router = useRouter()
+const loading = ref(false)
+const rooms = ref<RuleRoom[]>([])
+const ruleTitle = ref('规则房间')
+const ruleId = computed(() => String(route.params.ruleId || ''))
+
+async function loadRooms() {
+  loading.value = true
+  const [roomResult, detailResult] = await Promise.all([
+    marketApi.listRuleRooms(ruleId.value),
+    marketApi.getPublishedRuleDetail(ruleId.value),
+  ])
+  loading.value = false
+
+  if (detailResult.success && detailResult.data) {
+    ruleTitle.value = detailResult.data.name
+  }
+
+  if (!roomResult.success) {
+    ElMessage.error(roomResult.message || '房间列表加载失败')
+    return
+  }
+
+  rooms.value = roomResult.data || []
+}
+
+function createRoom() {
+  void router.push({
+    path: '/create-room',
+    query: {
+      ruleId: ruleId.value,
+      ruleName: ruleTitle.value,
+    },
+  })
+}
+
+function joinRoom(code: string) {
+  void router.push({
+    path: '/join-room',
+    query: { code },
+  })
+}
+
+onMounted(() => {
+  void loadRooms()
+})
+</script>
+
+<style scoped>
+.room-search-page {
+  min-height: 100%;
+  padding: 28px;
+  background: #f5f6fa;
+  color: #252633;
+  text-align: left;
+}
+
+.room-header,
+.room-card,
+.panel {
+  border: 1px solid #dfe3ec;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.room-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 22px 24px;
+  margin-bottom: 16px;
+}
+
+.room-header h1 {
+  margin: 0;
+  font-size: 26px;
+  letter-spacing: 0;
+}
+
+.room-header p {
+  margin-top: 6px;
+  color: #687083;
+}
+
+.panel {
+  padding: 24px;
+}
+
+.room-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 14px;
+}
+
+.room-card {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 18px 20px;
+}
+
+.room-card-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.room-card h2 {
+  margin: 0;
+  font-size: 22px;
+  letter-spacing: 0;
+}
+
+.room-card p {
+  margin-top: 6px;
+  color: #687083;
+}
+
+.room-info-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.room-info-item {
+  padding: 12px;
+  border: 1px solid #edf0f5;
+  border-radius: 8px;
+  background: #fbfcfe;
+}
+
+.room-info-item span {
+  display: block;
+  margin-bottom: 6px;
+  color: #687083;
+  font-size: 14px;
+}
+
+.room-info-item strong,
+.password-state {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: #252633;
+  font-size: 16px;
+}
+
+.join-btn {
+  width: 100%;
+}
+
+.market-btn {
+  min-width: 96px;
+  padding: 10px 22px;
+  border: 2px solid #222;
+  border-radius: 10px;
+  background: #fff;
+  color: #222;
+  font-weight: 600;
+}
+
+.market-btn:hover,
+.market-btn:focus {
+  border-color: #222;
+  background: #ece6fa;
+  color: #222;
+}
+
+.market-btn.is-disabled,
+.market-btn.is-disabled:hover {
+  border-color: #c8c8c8;
+  background: #f5f5f5;
+  color: #999;
+}
+
+@media (max-width: 760px) {
+  .room-header {
+    display: flex;
+    align-items: stretch;
+    flex-direction: column;
+  }
+}
+</style>

--- a/src/views/__tests__/CreateRoomView.spec.ts
+++ b/src/views/__tests__/CreateRoomView.spec.ts
@@ -9,6 +9,7 @@ const push = vi.fn()
 
 vi.mock('vue-router', () => ({
   useRouter: () => ({ push }),
+  useRoute: () => ({ query: {}, params: {}, path: '/create-room', name: 'create-room', fullPath: '/create-room' }),
 }))
 
 vi.mock('../../api/room', () => ({

--- a/src/views/__tests__/JoinRoomView.spec.ts
+++ b/src/views/__tests__/JoinRoomView.spec.ts
@@ -9,6 +9,7 @@ const push = vi.fn()
 
 vi.mock('vue-router', () => ({
   useRouter: () => ({ push }),
+  useRoute: () => ({ query: {}, params: {}, path: '/join-room', name: 'join-room', fullPath: '/join-room' }),
 }))
 
 vi.mock('../../api/room', () => ({


### PR DESCRIPTION
hillary 的原 PR #146 因为分支落后 main 5 天且 3 个测试断言过期被卡住。本 PR 是替代方案:

1. cherry-pick 046371a 把规则市场前端整套 (5 个 view + market.ts + 路由 + 导航) 搬到当前 main HEAD,作者仍然是 hillary
2. 修 3 个测试断言:
   - CreateRoomView.spec.ts / JoinRoomView.spec.ts:hillary 的视图开始用 useRoute 读市场来的查询参数,补 vue-router mock
   - MainLayout.spec.ts:规则市场入口正式启用,断言改成应当包含 "规则市场"

主体功能完全来自 hillary,我只补了测试。本 PR merge 后请关 #146。

## 验证
- npm run test:unit:90/90
- npm run build:类型零错误
- BE 规则市场后端 #117(评价系统)已部署生产,本 FE 合并后规则市场页面在公网即可端到端工作