### PR TITLE
fix(market): default rule market to real backend instead of mock data

### DIFF
--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -31,6 +31,7 @@ export const API_CONFIG = {
     userUseMock: false,
     roomUseMock: false,
     gameUseMock: false,
+    marketUseMock: false,
 
     endpoints: {
         user: {
@@ -69,4 +70,5 @@ export const shouldUseMockApi = (): boolean => API_CONFIG.USE_MOCK
 export const shouldUseUserMockApi = (): boolean => API_CONFIG.userUseMock ?? API_CONFIG.USE_MOCK
 export const shouldUseRoomMockApi = (): boolean => API_CONFIG.roomUseMock ?? API_CONFIG.USE_MOCK
 export const shouldUseGameMockApi = (): boolean => API_CONFIG.gameUseMock ?? API_CONFIG.USE_MOCK
+export const shouldUseMarketMockApi = (): boolean => API_CONFIG.marketUseMock ?? API_CONFIG.USE_MOCK
 

--- a/src/api/market.ts
+++ b/src/api/market.ts
@@ -1,4 +1,5 @@
 import { apiGet, apiPost } from './request'
+import { shouldUseMarketMockApi } from './config'
 import defaultAvatarUrl from '../assets/default-avatar.svg'
 
 export interface MarketDeveloper {
@@ -63,7 +64,7 @@ interface ReviewPayload {
   imageUrl?: string
 }
 
-const useMarketMock = import.meta.env.VITE_RULE_MARKET_USE_MOCK !== 'false'
+const useMarketMock = shouldUseMarketMockApi()
 
 const mockDeveloper: MarketDeveloper = {
   id: 'dev-demo',


### PR DESCRIPTION
## 问题

规则市场页一直只显示 2 条规则（Tiny Demo / Duel Demo），即使后端已发布 11 条。

## 根因

`src/api/market.ts:66` PR #146 引入的 mock 开关默认开启：

```ts
const useMarketMock = import.meta.env.VITE_RULE_MARKET_USE_MOCK !== 'false'
```

只有显式设 env 为 `'false'` 才会走真后端，否则一律返回 `mockRules`（写死的 2 条 demo）。

其它模块（user/room/game）都已通过 `API_CONFIG.xxxUseMock: false` 统一关闭 mock，只有 market 自己读 env 且默认开。

## 修复

把 market 也接进 `API_CONFIG`：
- `config.ts` 加 `marketUseMock: false` + 导出 `shouldUseMarketMockApi()`
- `market.ts` 用 helper 替代直接读 env

修完后浏览器规则市场页将看到 11 条真实规则，包含本周新加的 4 款预设：War 拼点战争 / 99 累加 / 大老二极简版 / 21 点（伪版）。

## 测试

- `npm run test:unit` 90/90 全过
- `npm run build` 成功
