### PR TITLE
fix(market): use WildCard logo for system developer avatar

### DIFF
--- a/src/api/market.ts
+++ b/src/api/market.ts
@@ -1,6 +1,19 @@
 import { apiGet, apiPost } from './request'
 import { shouldUseMarketMockApi } from './config'
 import defaultAvatarUrl from '../assets/default-avatar.svg'
+import wildcardLogoUrl from '../assets/logo.svg'
+
+const SYSTEM_DEVELOPER_ID = 'system'
+
+export function resolveDeveloperAvatar(developer: { id: string; avatar: string }): string {
+  if (developer.avatar) {
+    return developer.avatar
+  }
+  if (developer.id === SYSTEM_DEVELOPER_ID) {
+    return wildcardLogoUrl
+  }
+  return defaultAvatarUrl
+}
 
 export interface MarketDeveloper {
   id: string

--- a/src/views/RuleDeveloperDetailView.vue
+++ b/src/views/RuleDeveloperDetailView.vue
@@ -53,8 +53,7 @@
 import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { ElMessage } from 'element-plus'
-import defaultAvatarUrl from '../assets/default-avatar.svg'
-import { marketApi, type PublishedRuleSummary } from '../api/market'
+import { marketApi, resolveDeveloperAvatar, type PublishedRuleSummary } from '../api/market'
 
 const route = useRoute()
 const router = useRouter()
@@ -65,7 +64,9 @@ const rules = ref<PublishedRuleSummary[]>([])
 const developerId = computed(() => String(route.params.developerId || ''))
 const firstRule = computed(() => rules.value[0])
 const developerName = computed(() => firstRule.value?.developer.name || '开发者')
-const developerAvatar = computed(() => firstRule.value?.developer.avatar || defaultAvatarUrl)
+const developerAvatar = computed(() =>
+  firstRule.value ? resolveDeveloperAvatar(firstRule.value.developer) : ''
+)
 const developerBio = computed(() => firstRule.value?.developer.bio || '该开发者还没有留下简介。')
 
 async function loadRules() {

--- a/src/views/RuleMarketDetailView.vue
+++ b/src/views/RuleMarketDetailView.vue
@@ -14,7 +14,7 @@
           </div>
         </div>
         <button type="button" class="developer-card" @click="openDeveloper">
-          <img :src="rule.developer.avatar" :alt="rule.developer.name">
+          <img :src="resolveDeveloperAvatar(rule.developer)" :alt="rule.developer.name">
           <strong>{{ rule.developer.name }}</strong>
         </button>
       </header>
@@ -80,7 +80,7 @@ import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { ElMessage } from 'element-plus'
 import type { UploadFile } from 'element-plus'
-import { marketApi, type PublishedRuleDetail } from '../api/market'
+import { marketApi, resolveDeveloperAvatar, type PublishedRuleDetail } from '../api/market'
 
 const route = useRoute()
 const router = useRouter()

--- a/src/views/RuleMarketHomeView.vue
+++ b/src/views/RuleMarketHomeView.vue
@@ -51,7 +51,7 @@
           </div>
           <p>{{ rule.description }}</p>
           <div class="developer-row">
-            <img :src="rule.developer.avatar" :alt="rule.developer.name">
+            <img :src="resolveDeveloperAvatar(rule.developer)" :alt="rule.developer.name">
             <span>{{ rule.developer.name }}</span>
           </div>
           <div class="card-footer">
@@ -69,7 +69,7 @@
 import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { ElMessage } from 'element-plus'
-import { marketApi, type PublishedRuleSummary } from '../api/market'
+import { marketApi, resolveDeveloperAvatar, type PublishedRuleSummary } from '../api/market'
 
 const router = useRouter()
 const loading = ref(false)


### PR DESCRIPTION
## 问题
规则市场所有 11 条规则的开发者头像都显示破图。
- 8 条内置规则的 developer.id=system，BE `market.rs` 硬编码 avatar=""
- 3 条用户规则（lj/lajipz）的用户从未上传过头像，DB 里 avatar 字段为空

## 修复
新增 `resolveDeveloperAvatar(developer)` helper（`src/api/market.ts`）：
- 有 avatar → 直接用
- `id === 'system'` → WildCard 官方 logo（`assets/logo.svg`）
- 其它空 → 默认占位头像

3 个 view（首页 / 详情页 / 开发者页）改用 helper；`RuleDeveloperDetailView` 顺手移除冗余的 `defaultAvatarUrl` import。

## 测试
- `npm run test:unit` 90/90 全过
- `npm run build` 成功
