### PR TITLE
feat(market): add Fork button to clone rules into draft

### DIFF
--- a/src/api/market.ts
+++ b/src/api/market.ts
@@ -66,6 +66,12 @@ interface ApiResult<T = unknown> {
   message?: string
 }
 
+export interface ForkRuleResponse {
+  id: string
+  status: 'draft' | 'published'
+  updatedAt: number
+}
+
 interface RuleQueryParams {
   keyword?: string
   type?: string
@@ -234,6 +240,22 @@ export const marketApi = {
             imageUrl: payload.imageUrl,
             createdAt: Date.now(),
           },
+        }),
+      },
+    )
+  },
+
+  async forkRule(ruleId: string, name: string): Promise<ApiResult<ForkRuleResponse>> {
+    return apiPost<ApiResult<ForkRuleResponse>>(
+      `/api/rules/published/${encodeURIComponent(ruleId)}/fork`,
+      { name },
+      {
+        useMock: useMarketMock,
+        mockFn: () => ({
+          // Mock 模式下不返伪造的 draftId——跳到 /creation-center/{id} 会拉不到草稿。
+          // 主动返失败，避免给用户造成"成功但页面 404"的误解。
+          success: false,
+          message: 'Fork 在 mock 模式下不可用，请关闭 marketUseMock 后重试',
         }),
       },
     )

--- a/src/composables/__tests__/useRuleFork.spec.ts
+++ b/src/composables/__tests__/useRuleFork.spec.ts
@@ -1,0 +1,128 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import { useRuleFork } from '../useRuleFork'
+import { marketApi } from '../../api/market'
+import { useUserStore } from '../../stores/userStore'
+
+const push = vi.fn()
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push }),
+}))
+
+vi.mock('../../api/market', async () => {
+  const actual = await vi.importActual<typeof import('../../api/market')>('../../api/market')
+  return {
+    ...actual,
+    marketApi: {
+      ...actual.marketApi,
+      forkRule: vi.fn(),
+    },
+  }
+})
+
+vi.mock('element-plus', async () => {
+  const actual = await vi.importActual<typeof import('element-plus')>('element-plus')
+  return {
+    ...actual,
+    ElMessage: {
+      success: vi.fn(),
+      error: vi.fn(),
+      warning: vi.fn(),
+    },
+    ElMessageBox: {
+      prompt: vi.fn(),
+    },
+  }
+})
+
+describe('useRuleFork', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('未登录时显示警告且不调用 API', async () => {
+    const { forkRule } = useRuleFork()
+
+    await forkRule({ id: 'rule-1', name: 'Demo' })
+
+    expect(ElMessage.warning).toHaveBeenCalledWith('请先登录后再 Fork 规则')
+    expect(ElMessageBox.prompt).not.toHaveBeenCalled()
+    expect(marketApi.forkRule).not.toHaveBeenCalled()
+    expect(push).not.toHaveBeenCalled()
+  })
+
+  it('登录后用户确认时调用 API 并跳转至创作中心', async () => {
+    const userStore = useUserStore()
+    userStore.applyUser({
+      id: 'user-1',
+      email: 'u@example.com',
+      username: 'tester',
+      avatar: '',
+    })
+
+    vi.mocked(ElMessageBox.prompt).mockResolvedValue({
+      value: 'My Fork',
+      action: 'confirm',
+    } as never)
+    vi.mocked(marketApi.forkRule).mockResolvedValue({
+      success: true,
+      data: { id: 'draft-42', status: 'draft', updatedAt: 123 },
+    })
+
+    const { forkRule } = useRuleFork()
+    await forkRule({ id: 'rule-1', name: 'Demo' })
+
+    expect(marketApi.forkRule).toHaveBeenCalledWith('rule-1', 'My Fork')
+    expect(ElMessage.success).toHaveBeenCalled()
+    expect(push).toHaveBeenCalledWith('/creation-center/draft-42')
+  })
+
+  it('登录但用户取消弹窗时不调用 API 也不跳转', async () => {
+    const userStore = useUserStore()
+    userStore.applyUser({
+      id: 'user-1',
+      email: 'u@example.com',
+      username: 'tester',
+      avatar: '',
+    })
+
+    vi.mocked(ElMessageBox.prompt).mockRejectedValue('cancel')
+
+    const { forkRule } = useRuleFork()
+    await forkRule({ id: 'rule-1', name: 'Demo' })
+
+    expect(marketApi.forkRule).not.toHaveBeenCalled()
+    expect(push).not.toHaveBeenCalled()
+    expect(ElMessage.error).not.toHaveBeenCalled()
+  })
+
+  it('Fork API 失败时显示错误消息', async () => {
+    const userStore = useUserStore()
+    userStore.applyUser({
+      id: 'user-1',
+      email: 'u@example.com',
+      username: 'tester',
+      avatar: '',
+    })
+
+    vi.mocked(ElMessageBox.prompt).mockResolvedValue({
+      value: 'My Fork',
+      action: 'confirm',
+    } as never)
+    vi.mocked(marketApi.forkRule).mockResolvedValue({
+      success: false,
+      message: '服务器错误',
+    })
+
+    const { forkRule } = useRuleFork()
+    await forkRule({ id: 'rule-1', name: 'Demo' })
+
+    expect(ElMessage.error).toHaveBeenCalledWith('服务器错误')
+    expect(push).not.toHaveBeenCalled()
+  })
+})

--- a/src/composables/useRuleFork.ts
+++ b/src/composables/useRuleFork.ts
@@ -1,0 +1,55 @@
+import { ElMessage, ElMessageBox } from 'element-plus'
+import { useRouter } from 'vue-router'
+import { marketApi, type PublishedRuleSummary } from '../api/market'
+import { useUserStore } from '../stores/userStore'
+
+export function useRuleFork() {
+  const router = useRouter()
+  const userStore = useUserStore()
+
+  async function forkRule(rule: Pick<PublishedRuleSummary, 'id' | 'name'>) {
+    if (!userStore.isLoggedIn) {
+      ElMessage.warning('请先登录后再 Fork 规则')
+      return
+    }
+
+    let inputName: string
+    try {
+      const result = await ElMessageBox.prompt('为你的副本起个名字', 'Fork 规则', {
+        confirmButtonText: '创建副本',
+        cancelButtonText: '取消',
+        inputValue: `${rule.name} (副本)`,
+        inputValidator: (val: string) => {
+          const trimmed = (val || '').trim()
+          if (!trimmed) return '名称不能为空'
+          if (trimmed.length > 255) return '名称过长（≤255）'
+          return true
+        },
+      })
+      inputName = (result.value || '').trim()
+    } catch (err) {
+      if (err !== 'cancel' && err !== 'close') {
+        console.warn('[useRuleFork] prompt unexpected error', err)
+      }
+      return
+    }
+
+    let apiResult
+    try {
+      apiResult = await marketApi.forkRule(rule.id, inputName)
+    } catch (err) {
+      console.warn('[useRuleFork] forkRule request failed', err)
+      ElMessage.error('Fork 请求失败，请稍后重试')
+      return
+    }
+    if (!apiResult.success || !apiResult.data) {
+      ElMessage.error(apiResult.message || 'Fork 失败')
+      return
+    }
+
+    ElMessage.success('副本已创建，正在进入创作中心…')
+    void router.push(`/creation-center/${encodeURIComponent(apiResult.data.id)}`)
+  }
+
+  return { forkRule }
+}

--- a/src/views/RuleMarketDetailView.vue
+++ b/src/views/RuleMarketDetailView.vue
@@ -30,6 +30,7 @@
           <div class="action-row">
             <el-button class="market-btn" @click="router.push(`/rule-market/${encodeURIComponent(rule.id)}/rooms`)">搜索房间</el-button>
             <el-button class="market-btn" @click="quickCreateRoom">快速使用规则</el-button>
+            <el-button class="market-btn" @click="handleFork">Fork 规则</el-button>
           </div>
         </section>
       </main>
@@ -81,6 +82,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { ElMessage } from 'element-plus'
 import type { UploadFile } from 'element-plus'
 import { marketApi, resolveDeveloperAvatar, type PublishedRuleDetail } from '../api/market'
+import { useRuleFork } from '../composables/useRuleFork'
 
 const route = useRoute()
 const router = useRouter()
@@ -91,6 +93,14 @@ const reviewRating = ref(5)
 const reviewContent = ref('')
 const reviewImageUrl = ref('')
 const reviewImageName = ref('')
+const { forkRule } = useRuleFork()
+
+function handleFork() {
+  if (!rule.value) {
+    return
+  }
+  void forkRule({ id: rule.value.id, name: rule.value.name })
+}
 
 const ruleId = computed(() => String(route.params.ruleId || ''))
 const activeScreenshot = computed(() => rule.value?.screenshots[0] || rule.value?.coverUrl || '')

--- a/src/views/RuleMarketHomeView.vue
+++ b/src/views/RuleMarketHomeView.vue
@@ -59,6 +59,16 @@
             <span>{{ rule.rating.toFixed(1) }} · {{ rule.reviewCount }} 条评价</span>
             <span>{{ formatDate(rule.publishedAt) }}</span>
           </div>
+          <div class="card-actions">
+            <button
+              class="market-btn fork-btn"
+              type="button"
+              @click.stop="handleFork(rule)"
+              @keydown.enter.stop.prevent="handleFork(rule)"
+            >
+              Fork
+            </button>
+          </div>
         </div>
       </article>
     </main>
@@ -70,12 +80,18 @@ import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { ElMessage } from 'element-plus'
 import { marketApi, resolveDeveloperAvatar, type PublishedRuleSummary } from '../api/market'
+import { useRuleFork } from '../composables/useRuleFork'
 
 const router = useRouter()
 const loading = ref(false)
 const keyword = ref('')
 const selectedType = ref('')
 const rules = ref<PublishedRuleSummary[]>([])
+const { forkRule } = useRuleFork()
+
+function handleFork(rule: PublishedRuleSummary) {
+  void forkRule(rule)
+}
 
 const ruleTypes = computed(() => Array.from(new Set(rules.value.map((rule) => rule.type))).filter(Boolean))
 
@@ -267,6 +283,16 @@ onMounted(() => {
   flex-wrap: wrap;
   color: #687083;
   font-size: 13px;
+}
+
+.card-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.fork-btn {
+  min-width: 80px;
+  padding: 6px 16px;
 }
 
 @media (max-width: 760px) {


### PR DESCRIPTION
## 功能
规则市场每张卡片 + 详情页加 Fork 按钮：点击 → 弹输入框（默认 "{原名} (副本)"） → 调 BE → 跳 `/creation-center/{draftId}` 让用户在 RuleBuilder 二次创作。

## 改动
- **新建 `src/composables/useRuleFork.ts`**：抽出复用 composable，处理未登录拦截 / prompt / 取消区分 / API 调用 try-catch / 跳转
- **`src/api/market.ts`**：加 `forkRule(ruleId, name)` 方法 + `ForkRuleResponse` 类型
- **`src/views/RuleMarketHomeView.vue`**：卡片底部加 Fork 按钮，`@click.stop` 防冒泡到 `openRule`
- **`src/views/RuleMarketDetailView.vue`**：action-row 加 "Fork 规则" 按钮
- **`src/composables/__tests__/useRuleFork.spec.ts`**：4 个 vitest 用例

## 关键设计
- **未登录**：toast 提示后直接 return，不发任何请求
- **prompt cancel/close 与真错误区分**：`catch (err) { if (err !== 'cancel' && err !== 'close') console.warn(...) }`
- **API 网络错误**：单独 try/catch，避免 unhandled rejection
- **mock 失败兜底**：marketUseMock 启用时主动返失败而非假 draftId，避免跳到不存在的 /creation-center/mock-draft-XXX

## 测试
- `npm run test:unit` 94/94 全过（含新 4 个 useRuleFork 测试）
- `npm run build` 通过

依赖 BE PR https://github.com/BUAA-ISET/WildCard_BackEnd/pull/122 先合。
