### PR TITLE
fix(router): treat /teaminfo/* as public so header nav works in new tabs

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -130,8 +130,13 @@ const router = createRouter({
 router.beforeEach(async (to) => {
   const userStore = useUserStore()
   const publicPaths = new Set(['/user-info'])
+  // 团队介绍 / 联系我们 / 帮助中心 三页是公开静态页，谁都可看。
+  // 这里特别需要：当用户在已登录 tab 里 window.open('/teaminfo/...') 打开新窗时，
+  // 新 tab 的 sessionStorage 为空、读不到 token，beforeEach 会把它误识为未登录
+  // 然后强制重定向到 /user-info，导致用户感受是「点了顶部链接，没跳转」。
+  const isPublicPath = publicPaths.has(to.path) || to.path.startsWith('/teaminfo/')
 
-  if (!userStore.isLoggedIn && !publicPaths.has(to.path)) {
+  if (!userStore.isLoggedIn && !isPublicPath) {
     return { path: '/user-info' }
   }
 


### PR DESCRIPTION
## Bug
顶部导航的「团队介绍」「联系我们」「帮助中心」点击没反应（或者新窗打开后停在登录页）。

## 根因
- `MainLayout` 和 `InfoLayout` 都用 `window.open(routeUrl, '_blank')` 打开三个 teaminfo 页
- 用户 token 默认存在 `sessionStorage`（`src/api/user.ts:192`），**sessionStorage 不跨 tab 共享**
- 新打开的 tab → `userStore.isLoggedIn=false` → `router.beforeEach` 把它重定向到 `/user-info`
- 体验：点了链接没看到要去的页面

## 修复
`src/router/index.ts` 把 `/teaminfo/*` 视为公开路径（About / Contact / Help 本来就该是公开的），不再触发未登录强制重定向。

```ts
const isPublicPath = publicPaths.has(to.path) || to.path.startsWith('/teaminfo/')
if (!userStore.isLoggedIn && !isPublicPath) {
  return { path: '/user-info' }
}
```

## 不选其它方案的原因
- **把 token 改到 localStorage**：会改变现有"关闭 tab 即退出"的会话语义，影响范围大
- **改 window.open 为 router.push**：用户期望是新标签打开，改成当前 tab 跳转是行为回退

## 测试
- `npm run test:unit` 94/94 全过
- `npm run build` 成功
