### PR TITLE
fix(layout): make header nav links jump in-place instead of opening new tab

### DIFF
--- a/src/layouts/InfoLayout.vue
+++ b/src/layouts/InfoLayout.vue
@@ -24,20 +24,15 @@ import { useRouter } from 'vue-router';
 const router = useRouter();
 
 const handleTeamIntro = () => {
-  openRouteInNewWindow('/teaminfo/about');
+  void router.push('/teaminfo/about');
 };
 
 const handleContact = () => {
-  openRouteInNewWindow('/teaminfo/contact');
+  void router.push('/teaminfo/contact');
 };
 
 const handleHelp = () => {
-  openRouteInNewWindow('/teaminfo/help');
-};
-
-const openRouteInNewWindow = (path: string) => {
-  const routeUrl = router.resolve(path).href;
-  window.open(routeUrl, '_blank', 'noopener,noreferrer');
+  void router.push('/teaminfo/help');
 };
 </script>
 

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -63,20 +63,15 @@ const displayUsername = computed(() => username.value || '未登录')
 const displayEmail = computed(() => email.value || 'not logged in')
 
 const handleTeamIntro = () => {
-  openRouteInNewWindow('/teaminfo/about')
+  void router.push('/teaminfo/about')
 }
 
 const handleContact = () => {
-  openRouteInNewWindow('/teaminfo/contact')
+  void router.push('/teaminfo/contact')
 }
 
 const handleHelp = () => {
-  openRouteInNewWindow('/teaminfo/help')
-}
-
-const openRouteInNewWindow = (path: string) => {
-  const routeUrl = router.resolve(path).href
-  window.open(routeUrl, '_blank', 'noopener,noreferrer')
+  void router.push('/teaminfo/help')
 }
 </script>
 


### PR DESCRIPTION
## Bug
顶部 团队介绍 / 联系我们 / 帮助中心 链接点击会**打开新 tab**，而且新 tab 还是停在原页（前一个 PR #153 修了未登录被踢回登录页的部分，但 UX 本身不对）。

## 用户期望
和一般网站一样，**点链接 = 当前页内跳转**，不是开新窗口。

## 修复
`MainLayout.vue` / `InfoLayout.vue` 把 `openRouteInNewWindow(...) → window.open(routeUrl, '_blank', ...)` 改成 `router.push(path)`。

3 个 handler 各自直接 `void router.push('/teaminfo/xxx')`，删掉冗余的 helper。

`/teaminfo/*` 公开白名单（PR #153）保留，仍然对"直接访问 URL"或"未登录访问"场景有用。

## 测试
- `npm run test:unit` 94/94 全过
- `npm run build` OK
