### PR TITLE
test: cover rule market frontend flows

### DIFF
--- a/cypress/e2e/rule-market.cy.ts
+++ b/cypress/e2e/rule-market.cy.ts
@@ -1,0 +1,199 @@
+/// <reference types="cypress" />
+
+const rules = [
+  {
+    id: 'builtin-war-rule',
+    name: 'War 拼点战争',
+    description: '连续 5 轮翻牌比大小。',
+    type: '对战',
+    developer: { id: 'system', name: 'WildCard 内置', avatar: '' },
+    rating: 4.8,
+    reviewCount: 12,
+    publishedAt: Date.parse('2026-05-29T00:00:00Z'),
+  },
+  {
+    id: 'builtin-blackjack-rule',
+    name: '21 点（伪版）',
+    description: '双方各提交 3 张牌后直接比较。',
+    type: '策略',
+    developer: { id: 'dev-1', name: 'Rule Lab', avatar: '/avatar.png' },
+    rating: 4.1,
+    reviewCount: 5,
+    publishedAt: Date.parse('2026-05-28T00:00:00Z'),
+  },
+]
+
+const detail = {
+  ...rules[0],
+  introduction: '每名玩家翻出一张牌，点数更高者获得本轮胜场。',
+  screenshots: [],
+  reviews: [
+    {
+      id: 'review-1',
+      authorName: '测试玩家',
+      authorAvatar: '/avatar.png',
+      rating: 5,
+      content: '节奏很快',
+      createdAt: Date.parse('2026-05-29T01:00:00Z'),
+    },
+  ],
+}
+
+const rooms = [
+  {
+    id: 'room-1',
+    code: 'A1B2C3',
+    hostName: '房主A',
+    currentPlayers: 1,
+    maxPlayers: 2,
+    hasPassword: false,
+    status: 'waiting',
+  },
+]
+
+function corsHeaders(origin?: string | string[]) {
+  const requestOrigin = Array.isArray(origin) ? origin[0] : origin
+  return {
+    'access-control-allow-origin': requestOrigin || '*',
+    'access-control-allow-credentials': 'true',
+    'access-control-allow-methods': 'GET,POST,PUT,DELETE,OPTIONS',
+    'access-control-allow-headers': 'content-type,authorization',
+  }
+}
+
+const testUser = {
+  id: 'test-user',
+  email: 'player@example.com',
+  username: '测试玩家',
+  avatar: '/avatar.png',
+}
+
+function apiResponse<T>(body: T) {
+  return (req: Cypress.Request) => {
+    req.reply({
+      headers: corsHeaders(req.headers.origin),
+      body,
+    })
+  }
+}
+
+function visitAsLoggedIn(path: string) {
+  cy.visit('/user-info')
+  cy.wait('@getCurrentUser')
+  cy.visit(path)
+}
+
+describe('规则市场', () => {
+  beforeEach(() => {
+    cy.intercept('OPTIONS', /\/api\/.*$/, (req) => {
+      req.reply({
+        statusCode: 204,
+        headers: corsHeaders(req.headers.origin),
+      })
+    })
+    cy.intercept('GET', /\/api\/user\/current$/, apiResponse({ success: true, data: testUser })).as('getCurrentUser')
+    cy.intercept('GET', /\/api\/rules\/published(?:\?.*)?$/, apiResponse({ success: true, data: rules })).as('listRules')
+    cy.intercept('GET', /\/api\/rules\/published\/[^/]+\/rooms$/, apiResponse({ success: true, data: rooms })).as('listRuleRooms')
+    cy.intercept('GET', /\/api\/rules\/developers\/system\/rules(?:\?.*)?$/, apiResponse({ success: true, data: [rules[0]] })).as('listDeveloperRules')
+    cy.intercept('GET', /\/api\/rules\/published\/builtin-war-rule$/, apiResponse({ success: true, data: detail })).as('getRuleDetail')
+    cy.intercept('POST', /\/api\/rules\/published\/builtin-war-rule\/reviews$/, apiResponse({
+      success: true,
+      data: {
+        id: 'review-2',
+        authorName: '我',
+        authorAvatar: '/me.png',
+        rating: 5,
+        content: '值得推荐',
+        createdAt: Date.parse('2026-05-30T00:00:00Z'),
+      },
+    })).as('postReview')
+    cy.intercept('POST', /\/api\/rules\/published\/builtin-war-rule\/fork$/, apiResponse({
+      success: true,
+      data: {
+        id: 'forked-war-rule',
+        status: 'draft',
+        updatedAt: Date.parse('2026-05-30T00:00:00Z'),
+      },
+    })).as('forkRule')
+  })
+
+  it('浏览、搜索并进入规则详情', () => {
+    visitAsLoggedIn('/rule-market')
+    cy.wait('@listRules')
+
+    cy.contains('h1', '规则市场').should('be.visible')
+    cy.contains('.rule-card', 'War 拼点战争').should('be.visible')
+    cy.contains('.rule-card', 'WildCard 内置').should('be.visible')
+
+    cy.get('.keyword-input input').clear().type('War')
+    cy.contains('button', '搜索').click()
+    cy.wait('@listRules').its('request.url').should('include', 'keyword=War')
+
+    cy.contains('.rule-card', 'War 拼点战争').click()
+    cy.location('pathname').should('eq', '/rule-market/builtin-war-rule')
+    cy.wait('@getRuleDetail')
+    cy.contains('h1', 'War 拼点战争').should('be.visible')
+    cy.contains('每名玩家翻出一张牌').should('be.visible')
+    cy.contains('.review-item', '节奏很快').scrollIntoView().should('be.visible')
+  })
+
+  it('已登录用户可以 Fork 规则副本', () => {
+    visitAsLoggedIn('/rule-market')
+    cy.wait('@listRules')
+
+    cy.contains('.rule-card', 'War 拼点战争').within(() => {
+      cy.contains('button', 'Fork').click()
+    })
+    cy.get('.el-message-box').within(() => {
+      cy.get('input').clear().type('War 战争副本')
+      cy.contains('button', '创建副本').click()
+    })
+
+    cy.wait('@forkRule').its('request.body').should('deep.eq', {
+      name: 'War 战争副本',
+    })
+    cy.location('pathname').should('eq', '/creation-center/forked-war-rule')
+  })
+
+  it('详情页可以提交评论并跳转到快速用规则创建房间', () => {
+    visitAsLoggedIn('/rule-market/builtin-war-rule')
+    cy.wait('@getRuleDetail')
+
+    cy.get('.review-form textarea').type('值得推荐')
+    cy.contains('button', '提交评论').click()
+    cy.wait('@postReview').its('request.body').should('deep.include', {
+      rating: 5,
+      content: '值得推荐',
+    })
+    cy.contains('.review-item', '值得推荐').should('be.visible')
+
+    cy.contains('button', '快速使用规则').click()
+    cy.location('pathname').should('eq', '/create-room')
+    cy.location('search').should('include', 'ruleId=builtin-war-rule')
+  })
+
+  it('可以从详情页进入开发者规则和在线房间', () => {
+    visitAsLoggedIn('/rule-market/builtin-war-rule')
+    cy.wait('@getRuleDetail')
+
+    cy.get('.developer-card').click()
+    cy.location('pathname').should('eq', '/rule-market/developer/system')
+    cy.wait('@listDeveloperRules')
+    cy.contains('h1', 'WildCard 内置').should('be.visible')
+    cy.contains('.rule-row', 'War 拼点战争').should('be.visible')
+
+    cy.contains('.rule-row', 'War 拼点战争').click()
+    cy.location('pathname').should('eq', '/rule-market/builtin-war-rule')
+    cy.wait('@getRuleDetail')
+
+    cy.contains('button', '搜索房间').click()
+    cy.location('pathname').should('eq', '/rule-market/builtin-war-rule/rooms')
+    cy.wait('@listRuleRooms')
+    cy.wait('@getRuleDetail')
+    cy.contains('h1', 'War 拼点战争').should('be.visible')
+    cy.contains('.room-card', 'A1B2C3').should('be.visible')
+    cy.contains('.room-card', 'A1B2C3').contains('button', '加入').click()
+    cy.location('pathname').should('eq', '/join-room')
+    cy.location('search').should('include', 'code=A1B2C3')
+  })
+})

--- a/src/api/__tests__/market.spec.ts
+++ b/src/api/__tests__/market.spec.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { apiGet, apiPost } from '../request'
+import { marketApi, resolveDeveloperAvatar } from '../market'
+
+vi.mock('../request', () => ({
+  apiGet: vi.fn(),
+  apiPost: vi.fn(),
+}))
+
+describe('marketApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('lists published rules through the real backend endpoint with encoded filters', async () => {
+    vi.mocked(apiGet).mockResolvedValue({ success: true, data: [] })
+
+    await marketApi.listPublishedRules({ keyword: 'War & Duel', type: '对战' })
+
+    expect(apiGet).toHaveBeenCalledWith(
+      '/api/rules/published?keyword=War+%26+Duel&type=%E5%AF%B9%E6%88%98',
+      expect.objectContaining({ useMock: false }),
+    )
+  })
+
+  it('loads detail, developer rules, rooms, reviews, and fork endpoints with encoded ids', async () => {
+    vi.mocked(apiGet).mockResolvedValue({ success: true, data: [] })
+    vi.mocked(apiPost).mockResolvedValue({ success: true, data: {} })
+
+    await marketApi.getPublishedRuleDetail('rule/with space')
+    await marketApi.listDeveloperRules('dev/with space', { keyword: 'Tiny Demo' })
+    await marketApi.listRuleRooms('rule/with space')
+    await marketApi.postRuleReview('rule/with space', { rating: 5, content: 'Nice' })
+    await marketApi.forkRule('rule/with space', 'My Fork')
+
+    expect(apiGet).toHaveBeenNthCalledWith(
+      1,
+      '/api/rules/published/rule%2Fwith%20space',
+      expect.objectContaining({ useMock: false }),
+    )
+    expect(apiGet).toHaveBeenNthCalledWith(
+      2,
+      '/api/rules/developers/dev%2Fwith%20space/rules?keyword=Tiny+Demo',
+      expect.objectContaining({ useMock: false }),
+    )
+    expect(apiGet).toHaveBeenNthCalledWith(
+      3,
+      '/api/rules/published/rule%2Fwith%20space/rooms',
+      expect.objectContaining({ useMock: false }),
+    )
+    expect(apiPost).toHaveBeenNthCalledWith(
+      1,
+      '/api/rules/published/rule%2Fwith%20space/reviews',
+      { rating: 5, content: 'Nice' },
+      expect.objectContaining({ useMock: false }),
+    )
+    expect(apiPost).toHaveBeenNthCalledWith(
+      2,
+      '/api/rules/published/rule%2Fwith%20space/fork',
+      { name: 'My Fork' },
+      expect.objectContaining({ useMock: false }),
+    )
+  })
+})
+
+describe('resolveDeveloperAvatar', () => {
+  it('keeps explicit developer avatars', () => {
+    expect(resolveDeveloperAvatar({ id: 'dev-1', avatar: '/avatar.png' })).toBe('/avatar.png')
+  })
+
+  it('uses the WildCard logo for the system developer and the default avatar otherwise', () => {
+    const systemAvatar = resolveDeveloperAvatar({ id: 'system', avatar: '' })
+    const regularAvatar = resolveDeveloperAvatar({ id: 'dev-1', avatar: '' })
+
+    expect(systemAvatar).toBeTruthy()
+    expect(regularAvatar).toBeTruthy()
+    expect(systemAvatar).not.toBe(regularAvatar)
+  })
+})

--- a/src/views/__tests__/RuleDeveloperDetailView.spec.ts
+++ b/src/views/__tests__/RuleDeveloperDetailView.spec.ts
@@ -1,0 +1,134 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ElMessage } from 'element-plus'
+import { marketApi, type PublishedRuleSummary } from '../../api/market'
+import RuleDeveloperDetailView from '../RuleDeveloperDetailView.vue'
+
+const push = vi.fn()
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: { developerId: 'system' } }),
+  useRouter: () => ({ push }),
+}))
+
+vi.mock('../../api/market', async () => {
+  const actual = await vi.importActual<typeof import('../../api/market')>('../../api/market')
+  return {
+    ...actual,
+    marketApi: {
+      ...actual.marketApi,
+      listDeveloperRules: vi.fn(),
+    },
+  }
+})
+
+vi.mock('element-plus', async () => {
+  const actual = await vi.importActual<typeof import('element-plus')>('element-plus')
+  return {
+    ...actual,
+    ElMessage: {
+      error: vi.fn(),
+    },
+  }
+})
+
+const rules: PublishedRuleSummary[] = [
+  {
+    id: 'builtin-war-rule',
+    name: 'War 拼点战争',
+    description: '连续 5 轮翻牌比大小。',
+    type: '对战',
+    developer: {
+      id: 'system',
+      name: 'WildCard 内置',
+      avatar: '',
+      bio: '官方内置规则。',
+    },
+    rating: 4.8,
+    reviewCount: 12,
+    publishedAt: new Date('2026-05-29T00:00:00Z').getTime(),
+  },
+  {
+    id: 'builtin-duel-rule',
+    name: 'Duel Demo',
+    description: '轻量对战规则。',
+    type: '策略',
+    developer: {
+      id: 'system',
+      name: 'WildCard 内置',
+      avatar: '',
+      bio: '官方内置规则。',
+    },
+    rating: 4.4,
+    reviewCount: 5,
+    publishedAt: new Date('2026-05-28T00:00:00Z').getTime(),
+  },
+]
+
+const stubs = {
+  ElButton: { emits: ['click'], inheritAttrs: false, template: '<button type="button" @click="$emit(\'click\')"><slot /></button>' },
+  ElIcon: { template: '<span><slot /></span>' },
+  Search: { template: '<span class="search-icon" />' },
+  ElInput: {
+    props: ['modelValue'],
+    emits: ['update:modelValue', 'clear'],
+    template: '<input v-bind="$attrs" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+  },
+  ElSkeleton: { template: '<div class="skeleton" />' },
+  ElEmpty: { props: ['description'], template: '<div class="empty">{{ description }}</div>' },
+  ElTag: { template: '<span class="tag"><slot /></span>' },
+  ElRate: { props: ['modelValue'], template: '<span class="rate">{{ modelValue }}</span>' },
+}
+
+function mountView() {
+  return mount(RuleDeveloperDetailView, {
+    global: { stubs },
+  })
+}
+
+describe('RuleDeveloperDetailView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(marketApi.listDeveloperRules).mockResolvedValue({ success: true, data: rules })
+  })
+
+  it('loads and renders developer profile data from the first returned rule', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(marketApi.listDeveloperRules).toHaveBeenCalledWith('system', { keyword: '' })
+    expect(wrapper.text()).toContain('WildCard 内置')
+    expect(wrapper.text()).toContain('官方内置规则。')
+    expect(wrapper.text()).toContain('War 拼点战争')
+    expect(wrapper.text()).toContain('Duel Demo')
+  })
+
+  it('searches this developer rules by keyword', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.find('input[placeholder="搜索该开发者发布的规则"]').setValue('War')
+    await wrapper.findAll('button').find(button => button.text() === '搜索')?.trigger('click')
+    await flushPromises()
+
+    expect(marketApi.listDeveloperRules).toHaveBeenLastCalledWith('system', { keyword: 'War' })
+  })
+
+  it('opens a selected rule detail page', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.find('.rule-row').trigger('click')
+
+    expect(push).toHaveBeenCalledWith('/rule-market/builtin-war-rule')
+  })
+
+  it('shows a load error when developer rules are unavailable', async () => {
+    vi.mocked(marketApi.listDeveloperRules).mockResolvedValueOnce({ success: false, message: 'developer unavailable' })
+
+    mountView()
+    await flushPromises()
+
+    expect(ElMessage.error).toHaveBeenCalledWith('developer unavailable')
+  })
+})

--- a/src/views/__tests__/RuleMarketDetailView.spec.ts
+++ b/src/views/__tests__/RuleMarketDetailView.spec.ts
@@ -1,0 +1,193 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ElMessage } from 'element-plus'
+import { marketApi, type PublishedRuleDetail } from '../../api/market'
+import RuleMarketDetailView from '../RuleMarketDetailView.vue'
+
+const push = vi.fn()
+const forkRule = vi.fn()
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: { ruleId: 'builtin-war-rule' } }),
+  useRouter: () => ({ push }),
+}))
+
+vi.mock('../../api/market', async () => {
+  const actual = await vi.importActual<typeof import('../../api/market')>('../../api/market')
+  return {
+    ...actual,
+    marketApi: {
+      ...actual.marketApi,
+      getPublishedRuleDetail: vi.fn(),
+      postRuleReview: vi.fn(),
+    },
+  }
+})
+
+vi.mock('../../composables/useRuleFork', () => ({
+  useRuleFork: () => ({ forkRule }),
+}))
+
+vi.mock('element-plus', async () => {
+  const actual = await vi.importActual<typeof import('element-plus')>('element-plus')
+  return {
+    ...actual,
+    ElMessage: {
+      success: vi.fn(),
+      error: vi.fn(),
+      warning: vi.fn(),
+    },
+  }
+})
+
+const rule: PublishedRuleDetail = {
+  id: 'builtin-war-rule',
+  name: 'War 拼点战争',
+  description: '连续 5 轮翻牌比大小。',
+  introduction: '每名玩家翻出一张牌，点数更高者获得本轮胜场。',
+  type: '对战',
+  developer: { id: 'system', name: 'WildCard 内置', avatar: '' },
+  rating: 4.8,
+  reviewCount: 12,
+  publishedAt: new Date('2026-05-29T00:00:00Z').getTime(),
+  screenshots: [],
+  reviews: [
+    {
+      id: 'review-1',
+      authorName: '测试玩家',
+      authorAvatar: '/avatar.png',
+      rating: 5,
+      content: '节奏很快',
+      createdAt: new Date('2026-05-29T01:00:00Z').getTime(),
+    },
+  ],
+}
+
+const stubs = {
+  ElButton: { emits: ['click'], inheritAttrs: false, template: '<button type="button" @click="$emit(\'click\')"><slot /></button>' },
+  ElSkeleton: { template: '<div class="skeleton" />' },
+  ElEmpty: { props: ['description'], template: '<div class="empty">{{ description }}</div>' },
+  ElTag: { template: '<span class="tag"><slot /></span>' },
+  ElRate: {
+    props: ['modelValue'],
+    emits: ['update:modelValue'],
+    template: '<input class="rate" type="number" :value="modelValue" @input="$emit(\'update:modelValue\', Number($event.target.value))" />',
+  },
+  ElInput: {
+    props: ['modelValue', 'type'],
+    emits: ['update:modelValue'],
+    template: '<textarea v-if="type === \'textarea\'" v-bind="$attrs" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" /><input v-else v-bind="$attrs" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+  },
+  ElUpload: { template: '<div class="upload"><slot /></div>' },
+}
+
+function mountView() {
+  return mount(RuleMarketDetailView, {
+    global: { stubs },
+  })
+}
+
+describe('RuleMarketDetailView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(marketApi.getPublishedRuleDetail).mockResolvedValue({ success: true, data: structuredClone(rule) })
+    vi.mocked(marketApi.postRuleReview).mockResolvedValue({
+      success: true,
+      data: {
+        id: 'review-2',
+        authorName: '我',
+        authorAvatar: '/me.png',
+        rating: 5,
+        content: '值得推荐',
+        createdAt: new Date('2026-05-30T00:00:00Z').getTime(),
+      },
+    })
+  })
+
+  it('loads and renders rule detail, developer, intro, and existing reviews', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(marketApi.getPublishedRuleDetail).toHaveBeenCalledWith('builtin-war-rule')
+    expect(wrapper.text()).toContain('War 拼点战争')
+    expect(wrapper.text()).toContain('每名玩家翻出一张牌')
+    expect(wrapper.text()).toContain('WildCard 内置')
+    expect(wrapper.text()).toContain('节奏很快')
+  })
+
+  it('navigates to developer, room search, and quick create destinations', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.find('.developer-card').trigger('click')
+    expect(push).toHaveBeenCalledWith('/rule-market/developer/system')
+
+    await wrapper.findAll('button').find(button => button.text() === '搜索房间')?.trigger('click')
+    expect(push).toHaveBeenCalledWith('/rule-market/builtin-war-rule/rooms')
+
+    await wrapper.findAll('button').find(button => button.text() === '快速使用规则')?.trigger('click')
+    expect(push).toHaveBeenCalledWith({
+      path: '/create-room',
+      query: { ruleId: 'builtin-war-rule', ruleName: 'War 拼点战争' },
+    })
+  })
+
+  it('uses the fork composable from the detail action', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.findAll('button').find(button => button.text() === 'Fork 规则')?.trigger('click')
+
+    expect(forkRule).toHaveBeenCalledWith({ id: 'builtin-war-rule', name: 'War 拼点战争' })
+  })
+
+  it('submits a trimmed review and prepends the returned review', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.find('textarea').setValue('  值得推荐  ')
+    await wrapper.findAll('button').find(button => button.text() === '提交评论')?.trigger('click')
+    await flushPromises()
+
+    expect(marketApi.postRuleReview).toHaveBeenCalledWith('builtin-war-rule', {
+      rating: 5,
+      content: '值得推荐',
+      imageUrl: undefined,
+    })
+    expect(wrapper.text()).toContain('我')
+    expect(wrapper.text()).toContain('值得推荐')
+    expect(ElMessage.success).toHaveBeenCalledWith('评论已提交')
+  })
+
+  it('shows a load error when rule detail is unavailable', async () => {
+    vi.mocked(marketApi.getPublishedRuleDetail).mockResolvedValueOnce({ success: false, message: 'detail unavailable' })
+
+    mountView()
+    await flushPromises()
+
+    expect(ElMessage.error).toHaveBeenCalledWith('detail unavailable')
+  })
+
+  it('shows an error when review submission fails', async () => {
+    vi.mocked(marketApi.postRuleReview).mockResolvedValueOnce({ success: false, message: 'review failed' })
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.find('textarea').setValue('值得推荐')
+    await wrapper.findAll('button').find(button => button.text() === '提交评论')?.trigger('click')
+    await flushPromises()
+
+    expect(ElMessage.error).toHaveBeenCalledWith('review failed')
+    expect(ElMessage.success).not.toHaveBeenCalled()
+  })
+
+  it('warns instead of submitting empty reviews', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.findAll('button').find(button => button.text() === '提交评论')?.trigger('click')
+
+    expect(marketApi.postRuleReview).not.toHaveBeenCalled()
+    expect(ElMessage.warning).toHaveBeenCalledWith('请填写评论内容')
+  })
+})

--- a/src/views/__tests__/RuleMarketHomeView.spec.ts
+++ b/src/views/__tests__/RuleMarketHomeView.spec.ts
@@ -1,0 +1,138 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ElMessage } from 'element-plus'
+import { marketApi, type PublishedRuleSummary } from '../../api/market'
+import RuleMarketHomeView from '../RuleMarketHomeView.vue'
+
+const push = vi.fn()
+const forkRule = vi.fn()
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push }),
+}))
+
+vi.mock('../../api/market', async () => {
+  const actual = await vi.importActual<typeof import('../../api/market')>('../../api/market')
+  return {
+    ...actual,
+    marketApi: {
+      ...actual.marketApi,
+      listPublishedRules: vi.fn(),
+    },
+  }
+})
+
+vi.mock('../../composables/useRuleFork', () => ({
+  useRuleFork: () => ({ forkRule }),
+}))
+
+vi.mock('element-plus', async () => {
+  const actual = await vi.importActual<typeof import('element-plus')>('element-plus')
+  return {
+    ...actual,
+    ElMessage: {
+      error: vi.fn(),
+    },
+  }
+})
+
+const rules: PublishedRuleSummary[] = [
+  {
+    id: 'builtin-war-rule',
+    name: 'War 拼点战争',
+    description: '连续 5 轮翻牌比大小。',
+    type: '对战',
+    developer: { id: 'system', name: 'WildCard 内置', avatar: '' },
+    rating: 4.8,
+    reviewCount: 12,
+    publishedAt: new Date('2026-05-29T00:00:00Z').getTime(),
+  },
+  {
+    id: 'rule-user-1',
+    name: 'Tiny Demo Plus',
+    description: '玩家自定义规则。',
+    type: '策略',
+    developer: { id: 'dev-1', name: 'Rule Lab', avatar: '/dev.png' },
+    rating: 4.2,
+    reviewCount: 3,
+    publishedAt: new Date('2026-05-28T00:00:00Z').getTime(),
+  },
+]
+
+const stubs = {
+  ElButton: { emits: ['click'], inheritAttrs: false, template: '<button type="button" @click="$emit(\'click\')"><slot /></button>' },
+  ElIcon: { template: '<span><slot /></span>' },
+  Search: { template: '<span class="search-icon" />' },
+  ElInput: {
+    props: ['modelValue'],
+    emits: ['update:modelValue', 'clear'],
+    template: '<input v-bind="$attrs" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+  },
+  ElSelect: {
+    props: ['modelValue'],
+    emits: ['update:modelValue', 'change'],
+    template: '<select v-bind="$attrs" :value="modelValue" @change="$emit(\'update:modelValue\', $event.target.value); $emit(\'change\', $event.target.value)"><slot /></select>',
+  },
+  ElOption: { props: ['label', 'value'], template: '<option :value="value">{{ label }}</option>' },
+  ElSkeleton: { template: '<div class="skeleton" />' },
+  ElEmpty: { props: ['description'], template: '<div class="empty">{{ description }}</div>' },
+  ElTag: { template: '<span class="tag"><slot /></span>' },
+  ElRate: { props: ['modelValue'], template: '<span class="rate">{{ modelValue }}</span>' },
+}
+
+function mountView() {
+  return mount(RuleMarketHomeView, {
+    global: { stubs },
+  })
+}
+
+describe('RuleMarketHomeView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(marketApi.listPublishedRules).mockResolvedValue({ success: true, data: rules })
+  })
+
+  it('loads and renders published rule cards from the market API', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(marketApi.listPublishedRules).toHaveBeenCalledWith({ keyword: '', type: '' })
+    expect(wrapper.text()).toContain('War 拼点战争')
+    expect(wrapper.text()).toContain('连续 5 轮翻牌比大小。')
+    expect(wrapper.text()).toContain('WildCard 内置')
+    expect(wrapper.text()).toContain('4.8 · 12 条评价')
+  })
+
+  it('searches with keyword and selected type filters', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.find('.keyword-input').setValue('War')
+    await wrapper.find('.type-select').setValue('对战')
+    await wrapper.findAll('button').find(button => button.text() === '搜索')?.trigger('click')
+    await flushPromises()
+
+    expect(marketApi.listPublishedRules).toHaveBeenLastCalledWith({ keyword: 'War', type: '对战' })
+  })
+
+  it('opens details from a card while Fork uses the fork composable without navigating', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.find('.fork-btn').trigger('click')
+    expect(forkRule).toHaveBeenCalledWith(rules[0])
+    expect(push).not.toHaveBeenCalled()
+
+    await wrapper.find('.rule-card').trigger('click')
+    expect(push).toHaveBeenCalledWith('/rule-market/builtin-war-rule')
+  })
+
+  it('shows a load error when the market API fails', async () => {
+    vi.mocked(marketApi.listPublishedRules).mockResolvedValueOnce({ success: false, message: 'market unavailable' })
+
+    mountView()
+    await flushPromises()
+
+    expect(ElMessage.error).toHaveBeenCalledWith('market unavailable')
+  })
+})

--- a/src/views/__tests__/RuleRoomSearchView.spec.ts
+++ b/src/views/__tests__/RuleRoomSearchView.spec.ts
@@ -1,0 +1,139 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ElMessage } from 'element-plus'
+import { marketApi, type PublishedRuleDetail, type RuleRoom } from '../../api/market'
+import RuleRoomSearchView from '../RuleRoomSearchView.vue'
+
+const push = vi.fn()
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: { ruleId: 'builtin-war-rule' } }),
+  useRouter: () => ({ push }),
+}))
+
+vi.mock('../../api/market', async () => {
+  const actual = await vi.importActual<typeof import('../../api/market')>('../../api/market')
+  return {
+    ...actual,
+    marketApi: {
+      ...actual.marketApi,
+      listRuleRooms: vi.fn(),
+      getPublishedRuleDetail: vi.fn(),
+    },
+  }
+})
+
+vi.mock('element-plus', async () => {
+  const actual = await vi.importActual<typeof import('element-plus')>('element-plus')
+  return {
+    ...actual,
+    ElMessage: {
+      error: vi.fn(),
+    },
+  }
+})
+
+const detail: PublishedRuleDetail = {
+  id: 'builtin-war-rule',
+  name: 'War 拼点战争',
+  description: '连续 5 轮翻牌比大小。',
+  introduction: '每名玩家翻出一张牌。',
+  type: '对战',
+  developer: { id: 'system', name: 'WildCard 内置', avatar: '' },
+  rating: 4.8,
+  reviewCount: 12,
+  publishedAt: new Date('2026-05-29T00:00:00Z').getTime(),
+  screenshots: [],
+  reviews: [],
+}
+
+const rooms: RuleRoom[] = [
+  {
+    id: 'room-1',
+    code: 'A1B2C3',
+    hostName: '房主A',
+    currentPlayers: 1,
+    maxPlayers: 2,
+    hasPassword: false,
+    status: 'waiting',
+  },
+  {
+    id: 'room-2',
+    code: 'D4E5F6',
+    hostName: '房主B',
+    currentPlayers: 2,
+    maxPlayers: 2,
+    hasPassword: true,
+    status: 'playing',
+  },
+]
+
+const stubs = {
+  ElButton: { props: ['disabled'], emits: ['click'], inheritAttrs: false, template: '<button type="button" :disabled="disabled" @click="$emit(\'click\')"><slot /></button>' },
+  ElSkeleton: { template: '<div class="skeleton" />' },
+  ElEmpty: { props: ['description'], template: '<div class="empty">{{ description }}</div>' },
+  ElTag: { props: ['type'], template: '<span class="tag"><slot /></span>' },
+  ElIcon: { template: '<span><slot /></span>' },
+  Lock: { template: '<span class="lock" />' },
+  Unlock: { template: '<span class="unlock" />' },
+}
+
+function mountView() {
+  return mount(RuleRoomSearchView, {
+    global: { stubs },
+  })
+}
+
+describe('RuleRoomSearchView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(marketApi.listRuleRooms).mockResolvedValue({ success: true, data: rooms })
+    vi.mocked(marketApi.getPublishedRuleDetail).mockResolvedValue({ success: true, data: detail })
+  })
+
+  it('loads rule title and online rooms for the selected rule', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(marketApi.listRuleRooms).toHaveBeenCalledWith('builtin-war-rule')
+    expect(marketApi.getPublishedRuleDetail).toHaveBeenCalledWith('builtin-war-rule')
+    expect(wrapper.text()).toContain('War 拼点战争')
+    expect(wrapper.text()).toContain('当前在线房间 2 个')
+    expect(wrapper.text()).toContain('A1B2C3')
+    expect(wrapper.text()).toContain('房主A')
+    expect(wrapper.text()).toContain('1 / 2')
+  })
+
+  it('opens quick create with the selected rule id and loaded title', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.findAll('button').find(button => button.text() === '快速创建房间')?.trigger('click')
+
+    expect(push).toHaveBeenCalledWith({
+      path: '/create-room',
+      query: { ruleId: 'builtin-war-rule', ruleName: 'War 拼点战争' },
+    })
+  })
+
+  it('opens join room with the selected room code', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.findAll('button').find(button => button.text() === '加入' && !button.attributes('disabled'))?.trigger('click')
+
+    expect(push).toHaveBeenCalledWith({
+      path: '/join-room',
+      query: { code: 'A1B2C3' },
+    })
+  })
+
+  it('shows a load error when the room list is unavailable', async () => {
+    vi.mocked(marketApi.listRuleRooms).mockResolvedValueOnce({ success: false, message: 'rooms unavailable' })
+
+    mountView()
+    await flushPromises()
+
+    expect(ElMessage.error).toHaveBeenCalledWith('rooms unavailable')
+  })
+})


### PR DESCRIPTION
## Summary
- Add unit tests for rule market API endpoint construction, avatar fallback, and page-level flows across market home, detail, developer, and room search views.
- Add Cypress e2e coverage for browsing/searching rules, Forking, submitting reviews, developer navigation, room search, and join-room routing.
- Keep changes test-only; no production frontend files are modified.

## Issues
Closes #156
Closes #157
Closes #158

## Test Plan
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] `./node_modules/.bin/start-server-and-test "VITE_ENABLE_TEST_SANDBOX=true npm run build && npx vite preview --host 127.0.0.1 --port 4173" http://127.0.0.1:4173 "npx cypress run --browser electron --spec cypress/e2e/rule-market.cy.ts"`

## Notes
- A potential route-param reuse defect in `RuleMarketDetailView.vue` was recorded locally at `/Data/erhuo/rule-market-route-param-defect.md`; it is intentionally not fixed here because this PR is test-only.
