### PR TITLE
fix(market): upload review image to backend before submitting

### DIFF
--- a/src/api/market.ts
+++ b/src/api/market.ts
@@ -1,5 +1,6 @@
 import { apiGet, apiPost } from './request'
-import { shouldUseMarketMockApi } from './config'
+import { getApiUrl, shouldUseMarketMockApi } from './config'
+import { AUTH_TOKEN_STORAGE_KEY } from '../utils/storageNamespace'
 import defaultAvatarUrl from '../assets/default-avatar.svg'
 import wildcardLogoUrl from '../assets/logo.svg'
 
@@ -259,5 +260,54 @@ export const marketApi = {
         }),
       },
     )
+  },
+
+  /**
+   * 把图片 multipart 上传到 BE，拿到一个短 URL（/static/review-images/<uuid>.<ext>）
+   * 再用这个 URL 作为 createReview 的 imageUrl 字段。
+   * 之前的实现是把图片 base64 dataURL 直接塞进 imageUrl，会撞 DB 的 VARCHAR(512) 限制。
+   */
+  async uploadReviewImage(file: File): Promise<ApiResult<{ imageUrl: string }>> {
+    if (useMarketMock) {
+      // mock 模式回退为 dataURL，仅供本地预览。
+      const dataUrl: string = await new Promise((resolve, reject) => {
+        const reader = new FileReader()
+        reader.onload = () => resolve(String(reader.result || ''))
+        reader.onerror = () => reject(reader.error)
+        reader.readAsDataURL(file)
+      })
+      return { success: true, data: { imageUrl: dataUrl } }
+    }
+
+    const form = new FormData()
+    form.append('file', file)
+    const url = getApiUrl('/api/rules/reviews/images')
+    const token =
+      (typeof window !== 'undefined' &&
+        (window.sessionStorage.getItem(AUTH_TOKEN_STORAGE_KEY) ||
+          window.localStorage.getItem(AUTH_TOKEN_STORAGE_KEY))) ||
+      ''
+    const headers: Record<string, string> = {}
+    if (token) headers.Authorization = `Bearer ${token}`
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        credentials: 'include',
+        headers,
+        body: form,
+      })
+      const text = await response.text()
+      const result = text ? JSON.parse(text) : {}
+      if (!response.ok) {
+        return {
+          success: false,
+          message: result?.message || `上传失败 (HTTP ${response.status})`,
+        }
+      }
+      return result
+    } catch (err) {
+      console.warn('[marketApi.uploadReviewImage] request failed', err)
+      return { success: false, message: '图片上传失败，请稍后重试' }
+    }
   },
 }

--- a/src/views/RuleMarketDetailView.vue
+++ b/src/views/RuleMarketDetailView.vue
@@ -93,6 +93,7 @@ const reviewRating = ref(5)
 const reviewContent = ref('')
 const reviewImageUrl = ref('')
 const reviewImageName = ref('')
+const reviewImageFile = ref<File | null>(null)
 const { forkRule } = useRuleFork()
 
 function handleFork() {
@@ -155,10 +156,23 @@ async function submitReview() {
   }
 
   submitting.value = true
+
+  // 先上传图片（如果有），再带短 URL 发评论。
+  let uploadedImageUrl: string | undefined
+  if (reviewImageFile.value) {
+    const upload = await marketApi.uploadReviewImage(reviewImageFile.value)
+    if (!upload.success || !upload.data) {
+      submitting.value = false
+      ElMessage.error(upload.message || '图片上传失败')
+      return
+    }
+    uploadedImageUrl = upload.data.imageUrl
+  }
+
   const result = await marketApi.postRuleReview(rule.value.id, {
     rating: reviewRating.value,
     content: reviewContent.value.trim(),
-    imageUrl: reviewImageUrl.value.trim() || undefined,
+    imageUrl: uploadedImageUrl,
   })
   submitting.value = false
 
@@ -184,10 +198,12 @@ function handleImageChange(file: UploadFile) {
     return
   }
 
+  // 保留原 File 给提交时上传；同时读 dataURL 仅用于本地预览。
+  reviewImageFile.value = rawFile
+  reviewImageName.value = rawFile.name
   const reader = new FileReader()
   reader.onload = () => {
     reviewImageUrl.value = typeof reader.result === 'string' ? reader.result : ''
-    reviewImageName.value = rawFile.name
   }
   reader.readAsDataURL(rawFile)
 }
@@ -195,6 +211,7 @@ function handleImageChange(file: UploadFile) {
 function clearReviewImage() {
   reviewImageUrl.value = ''
   reviewImageName.value = ''
+  reviewImageFile.value = null
 }
 
 onMounted(() => {


### PR DESCRIPTION
## Bug
规则市场详情页提交「带图片的评论」一定失败。

## 修复
- 保留 picker 拿到的 `File` 对象，dataURL 仅用作本地预览
- submit 时先 `marketApi.uploadReviewImage(file)` multipart 上传拿短 URL
- 再以短 URL 作为 `imageUrl` 调 `postRuleReview`
- mock 模式回退为 dataURL，保留本地预览能力

依赖 BE PR https://github.com/BUAA-ISET/WildCard_BackEnd/pull/... 先合（新增 `POST /api/rules/reviews/images`）。

## 测试
- `npm run test:unit` 94/94 全过
- `npm run build` 通过（TS 检查通过）
