### PR TITLE
fix(theme): darken root --text and override Element Plus gray scale

### DIFF
--- a/src/components/rule-builder/RuleComponentPalette.vue
+++ b/src/components/rule-builder/RuleComponentPalette.vue
@@ -86,7 +86,7 @@ const groupedTemplates = computed(() => {
 
 .panel-header p {
   margin: 0;
-  color: #777f8f;
+  color: #3a4050;
   font-size: 13px;
 }
 

--- a/src/components/rule-builder/RuleFlowCanvas.vue
+++ b/src/components/rule-builder/RuleFlowCanvas.vue
@@ -324,7 +324,7 @@ defineExpose({
 
 .canvas-toolbar p {
   margin: 0;
-  color: #737c8d;
+  color: #3a4050;
   font-size: 13px;
 }
 

--- a/src/components/rule-builder/RuleFlowNode.vue
+++ b/src/components/rule-builder/RuleFlowNode.vue
@@ -291,7 +291,7 @@ const returnDisplay = computed(() => displayReference(returnValue.value))
   border: 1px dashed #b8c2d4;
   border-radius: 6px;
   background: #f8f9fc;
-  color: #697386;
+  color: #3a4050;
   font-size: 12px;
 }
 
@@ -329,7 +329,7 @@ const returnDisplay = computed(() => displayReference(returnValue.value))
   border: 1px dashed #b8c2d4;
   border-radius: 6px;
   background: #f8f9fc;
-  color: #697386;
+  color: #3a4050;
   font-size: 12px;
 }
 
@@ -373,7 +373,7 @@ const returnDisplay = computed(() => displayReference(returnValue.value))
   border: 1px dashed #b8c2d4;
   border-radius: 6px;
   background: #f8f9fc;
-  color: #697386;
+  color: #3a4050;
   font-size: 12px;
 }
 
@@ -430,7 +430,7 @@ const returnDisplay = computed(() => displayReference(returnValue.value))
   border: 1px dashed #b8c2d4;
   border-radius: 6px;
   background: #f8f9fc;
-  color: #697386;
+  color: #3a4050;
   font-size: 12px;
 }
 
@@ -479,7 +479,7 @@ const returnDisplay = computed(() => displayReference(returnValue.value))
   border: 1px dashed #b8c2d4;
   border-radius: 6px;
   background: #f8f9fc;
-  color: #697386;
+  color: #3a4050;
   font-size: 12px;
 }
 
@@ -517,7 +517,7 @@ const returnDisplay = computed(() => displayReference(returnValue.value))
   border: 1px dashed #b8c2d4;
   border-radius: 6px;
   background: #f8f9fc;
-  color: #697386;
+  color: #3a4050;
   font-size: 12px;
 }
 
@@ -566,7 +566,7 @@ const returnDisplay = computed(() => displayReference(returnValue.value))
   border: 1px dashed #b8c2d4;
   border-radius: 6px;
   background: #f8f9fc;
-  color: #697386;
+  color: #3a4050;
   font-size: 12px;
 }
 

--- a/src/components/rule-builder/RuleJsonPreview.vue
+++ b/src/components/rule-builder/RuleJsonPreview.vue
@@ -65,7 +65,7 @@ defineEmits<{
 
 .panel-header p {
   margin: 0;
-  color: #777f8f;
+  color: #3a4050;
   font-size: 13px;
 }
 

--- a/src/components/rule-builder/RulePropertyPanel.vue
+++ b/src/components/rule-builder/RulePropertyPanel.vue
@@ -2105,7 +2105,7 @@ const updateRawContent = (value: string | number) => {
 
 .panel-header p {
   margin: 0;
-  color: #777f8f;
+  color: #3a4050;
   font-size: 13px;
 }
 
@@ -2179,7 +2179,7 @@ const updateRawContent = (value: string | number) => {
 .embedded-index-summary span {
   display: block;
   margin-bottom: 4px;
-  color: #697386;
+  color: #3a4050;
   font-size: 12px;
 }
 
@@ -2206,7 +2206,7 @@ const updateRawContent = (value: string | number) => {
 .assignment-summary span,
 .assignment-summary small {
   display: block;
-  color: #697386;
+  color: #3a4050;
   font-size: 12px;
 }
 
@@ -2235,7 +2235,7 @@ const updateRawContent = (value: string | number) => {
 .operand-summary span {
   display: block;
   margin-bottom: 4px;
-  color: #697386;
+  color: #3a4050;
   font-size: 12px;
 }
 
@@ -2262,7 +2262,7 @@ const updateRawContent = (value: string | number) => {
 .logic-component-summary span {
   display: block;
   margin-bottom: 4px;
-  color: #697386;
+  color: #3a4050;
   font-size: 12px;
 }
 
@@ -2289,7 +2289,7 @@ const updateRawContent = (value: string | number) => {
 .return-value-summary span {
   display: block;
   margin-bottom: 4px;
-  color: #697386;
+  color: #3a4050;
   font-size: 12px;
 }
 
@@ -2320,7 +2320,7 @@ const updateRawContent = (value: string | number) => {
   border: 1px dashed #c3cad8;
   border-radius: 8px;
   background: #f8f9fc;
-  color: #697386;
+  color: #3a4050;
   font-size: 13px;
 }
 
@@ -2422,7 +2422,7 @@ const updateRawContent = (value: string | number) => {
   border: 1px dashed #c3cad8;
   border-radius: 8px;
   background: #f8f9fc;
-  color: #697386;
+  color: #3a4050;
   font-size: 13px;
 }
 
@@ -2448,7 +2448,7 @@ const updateRawContent = (value: string | number) => {
 .comparison-summary span {
   display: block;
   margin-bottom: 4px;
-  color: #697386;
+  color: #3a4050;
   font-size: 12px;
 }
 

--- a/src/components/rule-builder/RuleStructurePanel.vue
+++ b/src/components/rule-builder/RuleStructurePanel.vue
@@ -262,7 +262,7 @@ const removeActiveCardsetProperty = (propertyId: string) => {
 
 .panel-header p {
   margin: 0;
-  color: #777f8f;
+  color: #3a4050;
   font-size: 13px;
 }
 
@@ -413,7 +413,7 @@ const removeActiveCardsetProperty = (propertyId: string) => {
 
 .object-summary span {
   margin-top: 4px;
-  color: #737c8d;
+  color: #3a4050;
   font-size: 12px;
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -1,5 +1,7 @@
 :root {
-  --text: #6b6375;
+  /* 基础文字色：原来是 #6b6375，白底对比度 5.07 偏淡；用户反馈"看不清"。
+   * 加深到 #3a3340，白底对比度 9.6，AAA。 */
+  --text: #3a3340;
   --text-h: #08060d;
   --bg: #fff;
   --border: #e5e4e7;
@@ -8,6 +10,14 @@
   --accent-bg: rgba(170, 59, 255, 0.1);
   --accent-border: rgba(170, 59, 255, 0.5);
   --social-bg: rgba(244, 243, 236, 0.5);
+
+  /* Element Plus 灰度系列覆盖：默认 placeholder / disabled / 次级文字
+   * 偏淡（#c0c4cc / #a8abb2 在白底 2.x 远不达标），整体加深。 */
+  --el-text-color-primary: #2a2530;
+  --el-text-color-regular: #3a3340;
+  --el-text-color-secondary: #555060;
+  --el-text-color-placeholder: #7a7585;
+  --el-text-color-disabled: #9a96a3;
   --shadow:
     rgba(0, 0, 0, 0.1) 0 10px 15px -3px, rgba(0, 0, 0, 0.05) 0 4px 6px -2px;
 

--- a/src/views/RuleBuilderView.vue
+++ b/src/views/RuleBuilderView.vue
@@ -935,7 +935,7 @@ const openTutorial = () => {
 
 .builder-header p {
   margin: 6px 0 0;
-  color: #737c8d;
+  color: #3a4050;
   font-size: 14px;
 }
 
@@ -1037,7 +1037,7 @@ const openTutorial = () => {
 
 .method-empty-state p {
   margin: 0 0 18px;
-  color: #737c8d;
+  color: #3a4050;
   font-size: 14px;
   line-height: 1.7;
 }
@@ -1093,7 +1093,7 @@ const openTutorial = () => {
 
 .step-item p {
   margin: 6px 0 0;
-  color: #737c8d;
+  color: #3a4050;
   font-size: 14px;
   line-height: 1.6;
 }


### PR DESCRIPTION
## 第二轮加深

PR #161 只动了 view 级 scoped CSS，遗漏两个上游源：

### 1. 全局 `:root --text`
原 `#6b6375`，白底 contrast 5.07（刚过 AA）。整个 body 默认继承此色，多个组件 fallback 到它。改为 `#3a3340`，白底 contrast 9.6（AAA）。

### 2. Element Plus 灰度变量
ElInput / ElRate / ElUpload 的 placeholder、副 label、disabled 文字走 Element 自家的灰度 token：
- `--el-text-color-secondary` 默认 #909399（contrast 3.14）
- `--el-text-color-placeholder` 默认 #a8abb2（contrast 2.79）

都远不达标。在 `:root` 里整体覆盖：
```css
--el-text-color-primary: #2a2530;
--el-text-color-regular: #3a3340;
--el-text-color-secondary: #555060;
--el-text-color-placeholder: #7a7585;
--el-text-color-disabled: #9a96a3;
```

### 3. 残留清理
rule-builder 组件里漏的 `#697386` / `#737c8d` / `#777f8f` 一并加深到 `#3a4050`。

## 测试
117/117 单测过，build OK。
