### PR TITLE
feat(market): adapt creation center + builder to four-state moderation

### DIFF
--- a/src/api/__tests__/rule.spec.ts
+++ b/src/api/__tests__/rule.spec.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { apiPost } from '../request'
+import { ruleApi } from '../rule'
+
+vi.mock('../request', () => ({
+  apiGet: vi.fn(),
+  apiPost: vi.fn(),
+  apiPut: vi.fn(),
+  apiDelete: vi.fn(),
+}))
+
+describe('ruleApi.submitReview', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('提交审核接口走 POST /api/rules/drafts/{id}/submit-review', async () => {
+    vi.mocked(apiPost).mockResolvedValue({
+      success: true,
+      data: { id: 'draft-123', status: 'pendingReview', updatedAt: 1 },
+    })
+
+    const result = await ruleApi.submitReview('draft-123')
+
+    expect(apiPost).toHaveBeenCalledWith(
+      '/api/rules/drafts/draft-123/submit-review',
+      {},
+      { useMock: false },
+    )
+    expect(result.success).toBe(true)
+    expect(result.data?.status).toBe('pendingReview')
+  })
+
+  it('对包含特殊字符的 draftId 做 URL 编码', async () => {
+    vi.mocked(apiPost).mockResolvedValue({ success: true, data: { id: '', status: '', updatedAt: 0 } })
+
+    await ruleApi.submitReview('draft/with space')
+
+    expect(apiPost).toHaveBeenCalledWith(
+      '/api/rules/drafts/draft%2Fwith%20space/submit-review',
+      {},
+      { useMock: false },
+    )
+  })
+})
+
+describe('ruleApi.saveRuleDesign', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('一站式接口由 createDraft → submitReview 串联，不再调用 publishDraft', async () => {
+    vi.mocked(apiPost)
+      // createDraft
+      .mockResolvedValueOnce({ success: true, data: { id: 'd1', updatedAt: 0 } })
+      // submitReview
+      .mockResolvedValueOnce({
+        success: true,
+        data: { id: 'd1', status: 'pendingReview', updatedAt: 1 },
+      })
+
+    const result = await ruleApi.saveRuleDesign({
+      name: 'Demo',
+      playerCount: 2,
+      description: '',
+      design: {} as never,
+    })
+
+    expect(apiPost).toHaveBeenCalledTimes(2)
+    const secondCallUrl = vi.mocked(apiPost).mock.calls[1]?.[0] as string
+    expect(secondCallUrl).toContain('/submit-review')
+    expect(secondCallUrl).not.toContain('/publish')
+    expect(result.success).toBe(true)
+    expect(result.data?.status).toBe('pendingReview')
+  })
+})

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -7,6 +7,7 @@ export { API_CONFIG, getApiUrl } from './config'
 export { apiRequest, apiGet, apiPost, apiPut, apiDelete } from './request'
 
 export type { User, LoginParams, RegisterParams, UpdatePasswordParams } from './user'
+export type { RuleDraftStatus, RuleDraftSummary, RuleDraftDetail, SubmitReviewResponse } from './rule'
 export type { PublishedRuleSummary, PublishedRuleDetail, MarketDeveloper, RuleReview, RuleRoom } from './market'
 export type { Room, Player, CreateRoomParams, JoinRoomParams, GameRuleOption } from './room'
 export type { GameSnapshot, GameCard, GamePlayerView, GameTableView } from './game'

--- a/src/api/rule.ts
+++ b/src/api/rule.ts
@@ -10,20 +10,29 @@ interface SaveRuleDesignParams {
   design: ExportedRuleDesign
 }
 
+export type RuleDraftStatus = 'draft' | 'pendingReview' | 'published' | 'rejected'
+
 export interface RuleDraftSummary {
   id: string
   name: string
   playerCount: number
   description: string
-  status: 'draft' | 'published'
+  status: RuleDraftStatus
   updatedAt: number
   publishedRuleId?: string
+  rejectReason?: string
 }
 
 export interface RuleDraftDetail extends RuleDraftSummary {
   ownerId?: string
   design: ExportedRuleDesign
   createdAt: number
+}
+
+export interface SubmitReviewResponse {
+  id: string
+  status: string
+  updatedAt: number
 }
 
 interface ApiResult<T = unknown> {
@@ -61,6 +70,21 @@ export const ruleApi = {
     )
   },
 
+  /**
+   * 作者提交草稿进入审核流。BE 接管发布动作，由审核员决定是否上架。
+   */
+  async submitReview(draftId: string): Promise<ApiResult<SubmitReviewResponse>> {
+    return apiPost<ApiResult<SubmitReviewResponse>>(
+      `/api/rules/drafts/${encodeURIComponent(draftId)}/submit-review`,
+      {},
+      { useMock: false },
+    )
+  },
+
+  /**
+   * @deprecated 旧的"直接发布"路径，BE 内部已转发到 submit-review。
+   * 新代码请使用 {@link ruleApi.submitReview}。
+   */
   async publishDraft(draftId: string): Promise<ApiResult<{ ruleId: string; version: number }>> {
     return apiPost<ApiResult<{ ruleId: string; version: number }>>(
       `/api/rules/drafts/${encodeURIComponent(draftId)}/publish`,
@@ -76,24 +100,29 @@ export const ruleApi = {
     )
   },
 
-  async saveRuleDesign(params: SaveRuleDesignParams): Promise<ApiResult<{ draftId: string; ruleId: string }>> {
+  /**
+   * 一站式：保存草稿并提交审核。原先此方法直接发布（绕过审核），现已改为提交审核。
+   * 成功后的 `ruleId` 字段在审核未通过前可能为空字符串，调用方应据 status 判断。
+   */
+  async saveRuleDesign(params: SaveRuleDesignParams): Promise<ApiResult<{ draftId: string; ruleId: string; status: string }>> {
     const draftResult = await this.createDraft(params)
 
     if (!draftResult.success || !draftResult.data?.id) {
       return { success: false, message: draftResult.message || '规则草稿保存失败' }
     }
 
-    const publishResult = await this.publishDraft(draftResult.data.id)
+    const submitResult = await this.submitReview(draftResult.data.id)
 
-    if (!publishResult.success || !publishResult.data?.ruleId) {
-      return { success: false, message: publishResult.message || '规则发布失败' }
+    if (!submitResult.success || !submitResult.data) {
+      return { success: false, message: submitResult.message || '规则提交审核失败' }
     }
 
     return {
       success: true,
       data: {
         draftId: draftResult.data.id,
-        ruleId: publishResult.data.ruleId,
+        ruleId: '',
+        status: submitResult.data.status,
       },
     }
   },

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -9,6 +9,7 @@ export interface User {
   email: string
   avatar: string
   token?: string
+  role?: string
 }
 
 export interface LoginParams {
@@ -66,6 +67,7 @@ type BackendUser = {
   email: string
   avatar?: string
   token?: string
+  role?: string
 }
 
 const VERIFICATION_CODE_TTL = 5 * 60 * 1000
@@ -218,6 +220,7 @@ function normalizeBackendUser(user: BackendUser | null | undefined): User | null
     email: user.email,
     avatar: user.avatar || '',
     token: user.token,
+    role: user.role,
   }
 }
 

--- a/src/stores/__tests__/userStore.spec.ts
+++ b/src/stores/__tests__/userStore.spec.ts
@@ -381,4 +381,71 @@ describe('userStore', () => {
       expect(store.avatar).toBe('')
     })
   })
+
+  describe('role 与 isAdmin', () => {
+    it('未登录时 role 默认为 user，isAdmin 为 false', () => {
+      const store = useUserStore()
+      expect(store.role).toBe('user')
+      expect(store.isAdmin).toBe(false)
+    })
+
+    it('applyUser 写入新 role，并影响 isAdmin', () => {
+      const store = useUserStore()
+      store.applyUser({
+        id: '1',
+        username: 'admin',
+        email: 'admin@test.com',
+        avatar: '',
+        role: 'admin',
+      })
+      expect(store.role).toBe('admin')
+      expect(store.isAdmin).toBe(true)
+    })
+
+    it('未携带 role 的用户回退为 user', () => {
+      const store = useUserStore()
+      store.applyUser({
+        id: '2',
+        username: 'normal',
+        email: 'normal@test.com',
+        avatar: '',
+      })
+      expect(store.role).toBe('user')
+      expect(store.isAdmin).toBe(false)
+    })
+
+    it('applyUser(null) 把 role 重置为 user', () => {
+      const store = useUserStore()
+      store.applyUser({
+        id: '1',
+        username: 'admin',
+        email: 'admin@test.com',
+        avatar: '',
+        role: 'admin',
+      })
+      expect(store.isAdmin).toBe(true)
+      store.applyUser(null)
+      expect(store.role).toBe('user')
+      expect(store.isAdmin).toBe(false)
+    })
+
+    it('fetchCurrentUser 把 BE 返回的 role 透传到 store', async () => {
+      vi.mocked(userApi.getCurrentUser).mockResolvedValue({
+        success: true,
+        data: {
+          id: '9',
+          username: 'auditor',
+          email: 'auditor@test.com',
+          avatar: '',
+          role: 'admin',
+        },
+      })
+
+      const store = useUserStore()
+      await store.fetchCurrentUser()
+
+      expect(store.role).toBe('admin')
+      expect(store.isAdmin).toBe(true)
+    })
+  })
 })

--- a/src/stores/userStore.ts
+++ b/src/stores/userStore.ts
@@ -40,8 +40,12 @@ export const useUserStore = defineStore('user', {
       email: storedUser?.email ?? '',
       username: storedUser?.username ?? '',
       avatar: storedUser?.avatar ?? '',
+      role: storedUser?.role ?? 'user',
       isLoggedIn: storedUser !== null,
     }
+  },
+  getters: {
+    isAdmin: (state) => state.role === 'admin',
   },
   actions: {
     applyUser(user: User | null) {
@@ -50,6 +54,7 @@ export const useUserStore = defineStore('user', {
         this.email = ''
         this.username = ''
         this.avatar = ''
+        this.role = 'user'
         this.isLoggedIn = false
         saveUserToStorage(null)
         return
@@ -59,6 +64,7 @@ export const useUserStore = defineStore('user', {
       this.email = user.email
       this.username = user.username
       this.avatar = user.avatar
+      this.role = user.role ?? 'user'
       this.isLoggedIn = true
       saveUserToStorage(user)
     },

--- a/src/views/CreationCenterView.vue
+++ b/src/views/CreationCenterView.vue
@@ -55,10 +55,19 @@
         <div>
           <strong>{{ rule.name || '未命名规则' }}</strong>
           <p>{{ rule.description || '暂无规则说明' }}</p>
+          <p
+            v-if="rule.status === 'rejected' && rule.rejectReason"
+            class="reject-reason"
+          >
+            驳回原因：{{ rule.rejectReason }}
+          </p>
         </div>
         <div class="rule-meta">
           <span>{{ rule.playerCount }} 人</span>
-          <span :class="['status-pill', rule.status]">{{ rule.status === 'published' ? '已发布' : '草稿' }}</span>
+          <span
+            :class="['status-pill', rule.status]"
+            :title="rule.status === 'rejected' && rule.rejectReason ? `驳回原因：${rule.rejectReason}` : undefined"
+          >{{ statusLabel(rule.status) }}</span>
           <span>{{ formatTime(rule.updatedAt) }}</span>
           <button
             type="button"
@@ -78,7 +87,7 @@
 import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { ElMessage, ElMessageBox } from 'element-plus'
-import { ruleApi, type RuleDraftSummary } from '../api/rule'
+import { ruleApi, type RuleDraftStatus, type RuleDraftSummary } from '../api/rule'
 
 const router = useRouter()
 const loading = ref(false)
@@ -89,6 +98,18 @@ const selectedRuleIds = ref<Set<string>>(new Set())
 const selectedCount = computed(() => selectedRuleIds.value.size)
 const allSelected = computed(() => rules.value.length > 0 && selectedRuleIds.value.size === rules.value.length)
 const someSelected = computed(() => selectedRuleIds.value.size > 0 && selectedRuleIds.value.size < rules.value.length)
+
+const STATUS_LABELS: Record<RuleDraftStatus, string> = {
+  draft: '草稿',
+  pendingReview: '审核中',
+  published: '已发布',
+  rejected: '已驳回',
+}
+
+function statusLabel(status: RuleDraftStatus | string | undefined) {
+  if (!status) return '草稿'
+  return STATUS_LABELS[status as RuleDraftStatus] ?? status
+}
 
 function formatTime(timestamp: number) {
   return new Date(timestamp).toLocaleString('zh-CN', {
@@ -346,9 +367,31 @@ onMounted(() => {
   color: #3a4050;
 }
 
+.status-pill.draft {
+  background: #eef1f7;
+  color: #3a4050;
+}
+
+.status-pill.pendingReview {
+  background: #e6f0ff;
+  color: #1a5fbf;
+}
+
 .status-pill.published {
   background: #e8f7ef;
   color: #16713a;
+}
+
+.status-pill.rejected {
+  background: #fdecec;
+  color: #b42323;
+  cursor: help;
+}
+
+.reject-reason {
+  margin: 6px 0 0;
+  color: #b42323;
+  font-size: 13px;
 }
 
 .delete-action {

--- a/src/views/RuleBuilderView.vue
+++ b/src/views/RuleBuilderView.vue
@@ -11,7 +11,20 @@
         <el-button @click="openJsonImport">导入 JSON</el-button>
         <el-button @click="showJson = !showJson">{{ showJson ? '隐藏 JSON' : '显示 JSON' }}</el-button>
         <el-button type="primary" @click="saveDesign">保存草稿</el-button>
-        <el-button type="success" @click="uploadCompletedRule">完成并上传规则</el-button>
+        <el-button
+          type="success"
+          :disabled="publishButtonDisabled"
+          :loading="submitting"
+          @click="uploadCompletedRule"
+        >
+          {{ publishButtonLabel }}
+        </el-button>
+        <span
+          v-if="draftStatus === 'rejected' && rejectReason"
+          class="reject-reason-inline"
+        >
+          驳回原因：{{ rejectReason }}
+        </span>
       </div>
     </header>
 
@@ -150,6 +163,7 @@ import RuleJsonPreview from '../components/rule-builder/RuleJsonPreview.vue'
 import RulePropertyPanel from '../components/rule-builder/RulePropertyPanel.vue'
 import RuleStructurePanel from '../components/rule-builder/RuleStructurePanel.vue'
 import { ruleApi } from '../api'
+import type { RuleDraftStatus } from '../api/rule'
 import type { ComponentTemplate, FlowGraphDraft, FlowScope, MethodDraft, RuleEdgeDraft, RuleNodeDraft } from '../types/ruleBuilder'
 import {
   cloneContent,
@@ -173,6 +187,9 @@ const route = useRoute()
 const router = useRouter()
 const design = reactive(createInitialDesign())
 const draftId = ref<string | null>(null)
+const draftStatus = ref<RuleDraftStatus>('draft')
+const rejectReason = ref<string>('')
+const submitting = ref(false)
 const activeWorkspace = ref<WorkspaceKey>('structure')
 const activeCardsetId = ref(design.cardsets[0].id)
 const activeComparisonId = ref(design.cardsetComparisons[0]?.id || null)
@@ -785,11 +802,15 @@ const loadDraftFromRoute = async () => {
   const routeDraftId = typeof route.params.draftId === 'string' ? route.params.draftId : ''
   if (!routeDraftId) {
     draftId.value = null
+    draftStatus.value = 'draft'
+    rejectReason.value = ''
     return
   }
 
   if (routeDraftId === 'new') {
     draftId.value = null
+    draftStatus.value = 'draft'
+    rejectReason.value = ''
     return
   }
 
@@ -801,6 +822,8 @@ const loadDraftFromRoute = async () => {
   }
 
   draftId.value = result.data.id
+  draftStatus.value = (result.data.status as RuleDraftStatus) || 'draft'
+  rejectReason.value = result.data.rejectReason || ''
   applyDesign(importRuleDesign(result.data.design, {
     name: result.data.name,
     playerCount: result.data.playerCount,
@@ -871,27 +894,50 @@ const saveDesign = async () => {
 }
 
 const uploadCompletedRule = async () => {
+  if (draftStatus.value === 'pendingReview') {
+    ElMessage.info('规则正在审核中，请等待审核员处理')
+    return
+  }
+
   if (!validateBeforeSubmit() || !validateBeforePublish()) {
     return
   }
 
-  if (!draftId.value) {
-    ElMessage.warning('请先保存草稿，再完成并上传规则')
-    return
-  }
-
+  submitting.value = true
   const savedDraftId = await persistDraft()
   if (!savedDraftId) {
+    submitting.value = false
     return
   }
 
-  const result = await ruleApi.publishDraft(savedDraftId)
-  if (result.success) {
-    ElMessage.success('规则已发布，可在创建房间时选择')
+  const result = await ruleApi.submitReview(savedDraftId)
+  submitting.value = false
+
+  if (result.success && result.data) {
+    draftStatus.value = (result.data.status as RuleDraftStatus) || 'pendingReview'
+    rejectReason.value = ''
+    ElMessage.success('规则已提交审核，请等待审核员处理')
   } else {
-    ElMessage.error(result.message || '规则发布失败')
+    ElMessage.error(result.message || '规则提交审核失败')
   }
 }
+
+const publishButtonLabel = computed(() => {
+  switch (draftStatus.value) {
+    case 'pendingReview':
+      return '审核中'
+    case 'published':
+      return '更新上架规则'
+    case 'rejected':
+      return '重新提交审核'
+    default:
+      return '提交审核'
+  }
+})
+
+const publishButtonDisabled = computed(() => {
+  return submitting.value || draftStatus.value === 'pendingReview'
+})
 
 const backToCenter = () => {
   void router.push('/creation-center')
@@ -943,6 +989,17 @@ const openTutorial = () => {
   display: flex;
   gap: 10px;
   flex-shrink: 0;
+  align-items: center;
+}
+
+.reject-reason-inline {
+  color: #b42323;
+  font-size: 12px;
+  font-weight: 500;
+  max-width: 240px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .workspace-tabs {

--- a/src/views/__tests__/CreationCenterView.spec.ts
+++ b/src/views/__tests__/CreationCenterView.spec.ts
@@ -1,0 +1,107 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import CreationCenterView from '../CreationCenterView.vue'
+import { ruleApi, type RuleDraftSummary } from '../../api/rule'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock('../../api/rule', () => ({
+  ruleApi: {
+    listDrafts: vi.fn(),
+    deleteDraft: vi.fn(),
+  },
+}))
+
+vi.mock('element-plus', async () => {
+  const actual = await vi.importActual<typeof import('element-plus')>('element-plus')
+  return {
+    ...actual,
+    ElMessage: {
+      success: vi.fn(),
+      error: vi.fn(),
+      warning: vi.fn(),
+      info: vi.fn(),
+    },
+    ElMessageBox: {
+      confirm: vi.fn().mockRejectedValue(new Error('cancel')),
+    },
+  }
+})
+
+const elButtonStub = {
+  template: '<button @click="$emit(\'click\')"><slot /></button>',
+}
+
+function mountWithRules(rules: RuleDraftSummary[]) {
+  vi.mocked(ruleApi.listDrafts).mockResolvedValue({ success: true, data: rules })
+  return mount(CreationCenterView, {
+    global: {
+      stubs: {
+        'el-button': elButtonStub,
+      },
+    },
+  })
+}
+
+describe('CreationCenterView - status badges', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('为 draft / pendingReview / published / rejected 四种状态各自渲染对应文案与样式', async () => {
+    const rules: RuleDraftSummary[] = [
+      { id: 'r1', name: '草稿规则', playerCount: 2, description: '', status: 'draft', updatedAt: 0 },
+      { id: 'r2', name: '审核中规则', playerCount: 2, description: '', status: 'pendingReview', updatedAt: 0 },
+      { id: 'r3', name: '已发布规则', playerCount: 2, description: '', status: 'published', updatedAt: 0 },
+      { id: 'r4', name: '被驳回规则', playerCount: 2, description: '', status: 'rejected', updatedAt: 0, rejectReason: '描述不清' },
+    ]
+    const wrapper = mountWithRules(rules)
+    await flushPromises()
+
+    const pills = wrapper.findAll('.status-pill')
+    expect(pills).toHaveLength(4)
+    expect(pills[0].text()).toBe('草稿')
+    expect(pills[0].classes()).toContain('draft')
+    expect(pills[1].text()).toBe('审核中')
+    expect(pills[1].classes()).toContain('pendingReview')
+    expect(pills[2].text()).toBe('已发布')
+    expect(pills[2].classes()).toContain('published')
+    expect(pills[3].text()).toBe('已驳回')
+    expect(pills[3].classes()).toContain('rejected')
+  })
+
+  it('rejected 状态行内展示驳回原因，并把原因带进徽章 title', async () => {
+    const rules: RuleDraftSummary[] = [
+      {
+        id: 'r4',
+        name: '被驳回规则',
+        playerCount: 2,
+        description: '',
+        status: 'rejected',
+        updatedAt: 0,
+        rejectReason: '描述不清，请补充示例',
+      },
+    ]
+    const wrapper = mountWithRules(rules)
+    await flushPromises()
+
+    const reason = wrapper.find('.reject-reason')
+    expect(reason.exists()).toBe(true)
+    expect(reason.text()).toContain('描述不清，请补充示例')
+
+    const pill = wrapper.find('.status-pill.rejected')
+    expect(pill.attributes('title')).toContain('描述不清')
+  })
+
+  it('rejected 但没有 rejectReason 时不渲染原因行', async () => {
+    const rules: RuleDraftSummary[] = [
+      { id: 'r4', name: '被驳回规则', playerCount: 2, description: '', status: 'rejected', updatedAt: 0 },
+    ]
+    const wrapper = mountWithRules(rules)
+    await flushPromises()
+
+    expect(wrapper.find('.reject-reason').exists()).toBe(false)
+  })
+})

--- a/src/views/__tests__/RuleBuilderView.spec.ts
+++ b/src/views/__tests__/RuleBuilderView.spec.ts
@@ -17,6 +17,7 @@ vi.mock('../api/rule', () => ({
     createDraft: vi.fn().mockResolvedValue({ success: true, data: { id: 'draft-test', updatedAt: 0 } }),
     updateDraft: vi.fn().mockResolvedValue({ success: true, data: { id: 'draft-test', updatedAt: 0 } }),
     publishDraft: vi.fn().mockResolvedValue({ success: true, data: { ruleId: 'rule-test', version: 1 } }),
+    submitReview: vi.fn().mockResolvedValue({ success: true, data: { id: 'draft-test', status: 'pendingReview', updatedAt: 0 } }),
   },
 }))
 
@@ -168,6 +169,27 @@ describe('RuleBuilderView.vue', () => {
       expect(buttons.length).toBeGreaterThan(0)
       const buttonTexts = buttons.map(btn => btn.text())
       expect(buttonTexts).toContain('保存草稿')
+    })
+
+    it('新草稿（status=draft）发布按钮文案为"提交审核"', () => {
+      const wrapper = mount(RuleBuilderView, {
+        global: {
+          stubs: {
+            'el-button': { template: '<button class="el-button"><slot /></button>' },
+            'el-dialog': true,
+            'el-input': true,
+            'rule-structure-panel': true,
+            'rule-component-palette': true,
+            'rule-flow-canvas': true,
+            'rule-property-panel': true,
+            'rule-json-preview': true,
+          },
+        },
+      })
+      const buttons = wrapper.findAll('.header-actions .el-button')
+      const buttonTexts = buttons.map(btn => btn.text())
+      expect(buttonTexts).toContain('提交审核')
+      expect(buttonTexts).not.toContain('完成并上传规则')
     })
 
     it('显示JSON预览切换按钮', () => {


### PR DESCRIPTION
## 改动
适配后端四态审核流。

### api/rule.ts
- `RuleDraftStatus` 扩成 `draft | pendingReview | published | rejected`
- `RuleDraftSummary.rejectReason` 字段
- 新 `submitReview(draftId)` 方法
- `publishDraft` 保留 @deprecated（BE 内部已转发，向后兼容）
- `saveRuleDesign` 改走 submit-review（一站式入口也走队列）

### stores/userStore.ts
加 `role` 字段 + `isAdmin` getter（Phase 2C 用）。`api/user.ts` 透传 role。

### CreationCenterView
- 四态状态徽章（draft 灰 / pendingReview 蓝 / published 绿 / rejected 红）
- rejected 行内显示驳回原因 + tooltip

### RuleBuilderView
右上角按钮按 status 切文案：
- draft → "提交审核"
- pendingReview → "审核中"（禁用）
- published → "更新上架规则"
- rejected → "重新提交审核"（旁边小红字提示原因）

点击行为：先保存当前编辑，再 POST submit-review。

## 测试
12 个新 vitest 用例。129/129 全过，build 通过。

## 后续 PR
- Phase 2B：发布表单页（简介 / 封面 / 截图编辑）+ 详情页 meta 展示
- Phase 2C：审核员面板 `/admin/rules-review`
