### PR TITLE
feat(market): add publish form + render rule meta in market

### DIFF
--- a/src/api/__tests__/rule.spec.ts
+++ b/src/api/__tests__/rule.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi, afterAll } from 'vitest'
 import { apiPost } from '../request'
 import { ruleApi } from '../rule'
 
@@ -7,6 +7,10 @@ vi.mock('../request', () => ({
   apiPost: vi.fn(),
   apiPut: vi.fn(),
   apiDelete: vi.fn(),
+}))
+
+vi.mock('../config', () => ({
+  getApiUrl: (endpoint: string) => `http://test${endpoint}`,
 }))
 
 describe('ruleApi.submitReview', () => {
@@ -72,5 +76,50 @@ describe('ruleApi.saveRuleDesign', () => {
     expect(secondCallUrl).not.toContain('/publish')
     expect(result.success).toBe(true)
     expect(result.data?.status).toBe('pendingReview')
+  })
+})
+
+describe('ruleApi.uploadRuleImage', () => {
+  const fetchMock = vi.fn()
+  const originalFetch = globalThis.fetch
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    fetchMock.mockReset()
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+  })
+
+  afterAll(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('multipart POST 到 /api/rules/drafts/{id}/images，并对 draftId 做编码', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      text: async () => JSON.stringify({ success: true, data: { imageUrl: '/static/rule-images/xyz.png' } }),
+    })
+    const file = new File(['x'], 'cover.png', { type: 'image/png' })
+
+    const result = await ruleApi.uploadRuleImage('draft id/1', file)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('http://test/api/rules/drafts/draft%20id%2F1/images')
+    expect(init.method).toBe('POST')
+    expect(init.body).toBeInstanceOf(FormData)
+    expect(result).toEqual({ success: true, data: { imageUrl: '/static/rule-images/xyz.png' } })
+  })
+
+  it('HTTP 非 2xx 时返回带 message 的失败结果', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 413,
+      text: async () => JSON.stringify({ message: '图片过大' }),
+    })
+    const file = new File(['x'], 'cover.png', { type: 'image/png' })
+
+    const result = await ruleApi.uploadRuleImage('d1', file)
+    expect(result.success).toBe(false)
+    expect(result.message).toBe('图片过大')
   })
 })

--- a/src/api/market.ts
+++ b/src/api/market.ts
@@ -103,8 +103,8 @@ const mockRules: PublishedRuleDetail[] = [
     rating: 4.6,
     reviewCount: 18,
     publishedAt: Date.now() - 1000 * 60 * 60 * 24 * 3,
-    coverUrl: '',
-    screenshots: [],
+    coverUrl: wildcardLogoUrl,
+    screenshots: [wildcardLogoUrl, defaultAvatarUrl],
     introduction: 'Tiny Demo 是一套短局制规则，强调快速发牌、即时比较和明确结算。它适合作为新玩家熟悉 WildCard 自定义规则流程的入门模板。',
     reviews: [
       {
@@ -131,7 +131,7 @@ const mockRules: PublishedRuleDetail[] = [
     rating: 4.3,
     reviewCount: 11,
     publishedAt: Date.now() - 1000 * 60 * 60 * 24 * 8,
-    coverUrl: '',
+    coverUrl: wildcardLogoUrl,
     screenshots: [],
     introduction: 'Duel Demo 保留了双人对抗的核心结构，并用更完整的流程演示规则构建器导出的运行逻辑。',
     reviews: [],

--- a/src/api/rule.ts
+++ b/src/api/rule.ts
@@ -1,5 +1,7 @@
 import type { ExportedRuleDesign } from '../types/ruleBuilder'
 import { apiDelete, apiGet, apiPost, apiPut } from './request'
+import { getApiUrl } from './config'
+import { AUTH_TOKEN_STORAGE_KEY } from '../utils/storageNamespace'
 
 const RULE_DRAFT_STORAGE_KEY = 'wildcard-rule-design-draft'
 
@@ -8,6 +10,9 @@ interface SaveRuleDesignParams {
   playerCount: number
   description: string
   design: ExportedRuleDesign
+  introduction?: string
+  coverUrl?: string
+  screenshotUrls?: string[]
 }
 
 export type RuleDraftStatus = 'draft' | 'pendingReview' | 'published' | 'rejected'
@@ -21,6 +26,9 @@ export interface RuleDraftSummary {
   updatedAt: number
   publishedRuleId?: string
   rejectReason?: string
+  introduction?: string
+  coverUrl?: string
+  screenshotUrls?: string[]
 }
 
 export interface RuleDraftDetail extends RuleDraftSummary {
@@ -98,6 +106,43 @@ export const ruleApi = {
       `/api/rules/drafts/${encodeURIComponent(draftId)}`,
       { useMock: false },
     )
+  },
+
+  /**
+   * 把规则相关图片（封面 / 截图）multipart 上传到 BE，拿到短 URL（/static/rule-images/<uuid>.<ext>）
+   * FE 拿到 imageUrl 后自行把它塞到 draft 的 coverUrl 或 screenshotUrls 字段，再走 updateDraft 持久化。
+   */
+  async uploadRuleImage(draftId: string, file: File): Promise<ApiResult<{ imageUrl: string }>> {
+    const form = new FormData()
+    form.append('file', file)
+    const url = getApiUrl(`/api/rules/drafts/${encodeURIComponent(draftId)}/images`)
+    const token =
+      (typeof window !== 'undefined' &&
+        (window.sessionStorage.getItem(AUTH_TOKEN_STORAGE_KEY) ||
+          window.localStorage.getItem(AUTH_TOKEN_STORAGE_KEY))) ||
+      ''
+    const headers: Record<string, string> = {}
+    if (token) headers.Authorization = `Bearer ${token}`
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        credentials: 'include',
+        headers,
+        body: form,
+      })
+      const text = await response.text()
+      const result = text ? JSON.parse(text) : {}
+      if (!response.ok) {
+        return {
+          success: false,
+          message: result?.message || `上传失败 (HTTP ${response.status})`,
+        }
+      }
+      return result
+    } catch (err) {
+      console.warn('[ruleApi.uploadRuleImage] request failed', err)
+      return { success: false, message: '图片上传失败，请稍后重试' }
+    }
   },
 
   /**

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -13,6 +13,7 @@ import JoinRoomView from '../views/JoinRoomView.vue'
 import CreateRoomView from '../views/CreateRoomView.vue'
 import CreationCenterView from '../views/CreationCenterView.vue'
 import RuleBuilderView from '../views/RuleBuilderView.vue'
+import PublishFormView from '../views/PublishFormView.vue'
 import RuleMarketHomeView from '../views/RuleMarketHomeView.vue'
 import RuleMarketDetailView from '../views/RuleMarketDetailView.vue'
 import RuleDeveloperDetailView from '../views/RuleDeveloperDetailView.vue'
@@ -65,6 +66,10 @@ const routes: RouteRecordRaw[] = [
       {
         path: 'creation-center/:draftId',
         component: RuleBuilderView
+      },
+      {
+        path: 'creation-center/:draftId/publish',
+        component: PublishFormView
       },
       {
         path: 'match-history',

--- a/src/views/CreationCenterView.vue
+++ b/src/views/CreationCenterView.vue
@@ -71,6 +71,14 @@
           <span>{{ formatTime(rule.updatedAt) }}</span>
           <button
             type="button"
+            class="publish-action"
+            :disabled="rule.status === 'pendingReview'"
+            @click.stop="openPublishForm(rule.id, rule.status)"
+          >
+            {{ publishButtonLabel(rule.status) }}
+          </button>
+          <button
+            type="button"
             class="delete-action"
             :disabled="deleting"
             @click.stop="deleteRule(rule.id)"
@@ -109,6 +117,26 @@ const STATUS_LABELS: Record<RuleDraftStatus, string> = {
 function statusLabel(status: RuleDraftStatus | string | undefined) {
   if (!status) return '草稿'
   return STATUS_LABELS[status as RuleDraftStatus] ?? status
+}
+
+function publishButtonLabel(status: RuleDraftStatus | string | undefined) {
+  switch (status) {
+    case 'pendingReview':
+      return '审核中'
+    case 'published':
+      return '更新上架规则'
+    case 'rejected':
+      return '重新发布'
+    default:
+      return '发布规则'
+  }
+}
+
+function openPublishForm(draftId: string, status: RuleDraftStatus | string | undefined) {
+  if (status === 'pendingReview') {
+    return
+  }
+  void router.push(`/creation-center/${encodeURIComponent(draftId)}/publish`)
 }
 
 function formatTime(timestamp: number) {
@@ -403,6 +431,31 @@ onMounted(() => {
   font: inherit;
   font-weight: 700;
   cursor: pointer;
+}
+
+.publish-action {
+  border: 1px solid #4f63ff;
+  padding: 4px 10px;
+  border-radius: 6px;
+  background: #eef1ff;
+  color: #2d3fb5;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.publish-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+  background: #eef1f7;
+  color: #6b7280;
+  border-color: #cbd0d8;
+}
+
+.publish-action:hover:not(:disabled),
+.publish-action:focus:not(:disabled) {
+  background: #dfe5ff;
+  outline: none;
 }
 
 .delete-action:disabled {

--- a/src/views/PublishFormView.vue
+++ b/src/views/PublishFormView.vue
@@ -1,0 +1,581 @@
+<template>
+  <div class="publish-page">
+    <header class="publish-header">
+      <div>
+        <h1>发布规则</h1>
+        <p v-if="ruleName" class="rule-name">{{ ruleName }} · {{ playerCount }} 人</p>
+      </div>
+      <div class="header-actions">
+        <el-button @click="backToCenter">返回创作中心</el-button>
+        <el-button @click="saveDraft" :loading="saving">保存草稿</el-button>
+        <el-button
+          type="primary"
+          :loading="submitting"
+          :disabled="submitDisabled"
+          @click="submitForReview"
+        >
+          {{ submitButtonLabel }}
+        </el-button>
+      </div>
+    </header>
+
+    <div
+      v-if="draftStatus === 'rejected' && rejectReason"
+      class="reject-banner"
+    >
+      上次审核被驳回：{{ rejectReason }}。修改后可重新提交审核。
+    </div>
+
+    <el-skeleton v-if="loading" :rows="6" animated />
+
+    <div v-else class="publish-grid">
+      <section class="card cover-card">
+        <h2>规则封面</h2>
+        <p class="muted">单张图片，建议 16:9。支持 png/jpeg/webp，最大 4MB。</p>
+        <div class="cover-area">
+          <div class="cover-preview">
+            <img v-if="coverUrl" :src="resolveImageUrl(coverUrl)" alt="封面预览">
+            <span v-else>暂无封面</span>
+          </div>
+          <div class="cover-actions">
+            <el-upload
+              :auto-upload="false"
+              :show-file-list="false"
+              accept="image/png,image/jpeg,image/webp"
+              :on-change="handleCoverChange"
+            >
+              <el-button :loading="uploadingCover">{{ coverUrl ? '更换封面' : '上传封面' }}</el-button>
+            </el-upload>
+            <el-button
+              v-if="coverUrl"
+              class="text-btn"
+              :disabled="uploadingCover"
+              @click="clearCover"
+            >
+              移除封面
+            </el-button>
+          </div>
+        </div>
+      </section>
+
+      <section class="card intro-card">
+        <h2>规则介绍</h2>
+        <p class="muted">支持换行；可以写玩法概述、更新日志等。</p>
+        <el-input
+          v-model="introduction"
+          type="textarea"
+          :rows="12"
+          maxlength="4000"
+          show-word-limit
+          placeholder="写下规则的玩法概述、亮点、更新日志……"
+        />
+      </section>
+
+      <section class="card shots-card">
+        <div class="shots-head">
+          <h2>规则截图</h2>
+          <span class="muted">最多 {{ MAX_SCREENSHOTS }} 张，支持 png/jpeg/webp，单张最大 4MB。</span>
+        </div>
+        <el-upload
+          :auto-upload="false"
+          :show-file-list="false"
+          :multiple="true"
+          accept="image/png,image/jpeg,image/webp"
+          :on-change="handleScreenshotChange"
+        >
+          <el-button :disabled="screenshotsFull || uploadingScreenshot">
+            {{ uploadingScreenshot ? '上传中…' : (screenshotsFull ? '已达上限' : '上传截图') }}
+          </el-button>
+        </el-upload>
+        <div v-if="screenshotUrls.length === 0" class="shots-empty muted">
+          还没有截图。
+        </div>
+        <ul v-else class="shots-list">
+          <li
+            v-for="(url, index) in screenshotUrls"
+            :key="url + index"
+            class="shot-item"
+          >
+            <img :src="resolveImageUrl(url)" :alt="`截图 ${index + 1}`">
+            <button
+              type="button"
+              class="shot-remove"
+              :disabled="uploadingScreenshot"
+              @click="removeScreenshot(index)"
+            >
+              移除
+            </button>
+          </li>
+        </ul>
+      </section>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { ElMessage } from 'element-plus'
+import type { UploadFile } from 'element-plus'
+import { ruleApi, type RuleDraftStatus } from '../api/rule'
+import { getApiUrl } from '../api/config'
+
+const MAX_SCREENSHOTS = 10
+const MAX_IMAGE_BYTES = 4 * 1024 * 1024
+const ACCEPTED_IMAGE_TYPES = new Set(['image/png', 'image/jpeg', 'image/webp'])
+
+const route = useRoute()
+const router = useRouter()
+
+const loading = ref(false)
+const saving = ref(false)
+const submitting = ref(false)
+const uploadingCover = ref(false)
+const uploadingScreenshot = ref(false)
+
+const draftId = ref<string>('')
+const ruleName = ref<string>('')
+const playerCount = ref<number>(0)
+const description = ref<string>('')
+const draftStatus = ref<RuleDraftStatus>('draft')
+const rejectReason = ref<string>('')
+
+const introduction = ref<string>('')
+const coverUrl = ref<string>('')
+const screenshotUrls = ref<string[]>([])
+
+// design 字段必须回传给 BE，否则 PUT draft 会把现有 design 覆盖空。
+// 进入页面时拉到的 design 直接缓存在内存中，本页不展示也不修改。
+let cachedDesign: unknown = null
+
+const screenshotsFull = computed(() => screenshotUrls.value.length >= MAX_SCREENSHOTS)
+
+const submitButtonLabel = computed(() => {
+  switch (draftStatus.value) {
+    case 'pendingReview':
+      return '审核中'
+    case 'published':
+      return '更新上架规则'
+    case 'rejected':
+      return '重新提交审核'
+    default:
+      return '提交审核'
+  }
+})
+
+const submitDisabled = computed(() => {
+  return draftStatus.value === 'pendingReview' || saving.value || uploadingCover.value || uploadingScreenshot.value
+})
+
+function backToCenter() {
+  void router.push('/creation-center')
+}
+
+/**
+ * BE 返回的图片 URL 形如 /static/rule-images/<uuid>.<ext>，是相对路径。
+ * 直接放进 <img src> 在 dev 模式（vite proxy）下能拿到，但在 prod 下需要拼上 API 域。
+ * 这里复用 getApiUrl 让两种环境都能正确显示。
+ */
+function resolveImageUrl(url: string) {
+  if (!url) return ''
+  if (/^(https?:|data:)/i.test(url)) {
+    return url
+  }
+  return getApiUrl(url)
+}
+
+async function loadDraft() {
+  const routeDraftId = typeof route.params.draftId === 'string' ? route.params.draftId : ''
+  if (!routeDraftId || routeDraftId === 'new') {
+    ElMessage.error('找不到对应的草稿')
+    await router.replace('/creation-center')
+    return
+  }
+
+  loading.value = true
+  const result = await ruleApi.getDraft(routeDraftId)
+  loading.value = false
+
+  if (!result.success || !result.data) {
+    ElMessage.error(result.message || '规则草稿加载失败')
+    await router.replace('/creation-center')
+    return
+  }
+
+  draftId.value = result.data.id
+  ruleName.value = result.data.name || ''
+  playerCount.value = result.data.playerCount || 0
+  description.value = result.data.description || ''
+  draftStatus.value = (result.data.status as RuleDraftStatus) || 'draft'
+  rejectReason.value = result.data.rejectReason || ''
+  introduction.value = result.data.introduction || ''
+  coverUrl.value = result.data.coverUrl || ''
+  screenshotUrls.value = Array.isArray(result.data.screenshotUrls) ? [...result.data.screenshotUrls] : []
+  cachedDesign = result.data.design
+}
+
+function validateImageFile(file: File | undefined): file is File {
+  if (!file) {
+    return false
+  }
+  if (!ACCEPTED_IMAGE_TYPES.has(file.type)) {
+    ElMessage.warning('仅支持 PNG / JPEG / WEBP 格式的图片')
+    return false
+  }
+  if (file.size > MAX_IMAGE_BYTES) {
+    ElMessage.warning('图片大小不能超过 4MB')
+    return false
+  }
+  return true
+}
+
+async function handleCoverChange(file: UploadFile) {
+  const raw = file.raw
+  if (!validateImageFile(raw)) {
+    return
+  }
+  if (!draftId.value) {
+    ElMessage.error('草稿尚未加载完成')
+    return
+  }
+
+  uploadingCover.value = true
+  const previousCover = coverUrl.value
+  const upload = await ruleApi.uploadRuleImage(draftId.value, raw)
+  if (!upload.success || !upload.data?.imageUrl) {
+    uploadingCover.value = false
+    ElMessage.error(upload.message || '封面上传失败')
+    return
+  }
+  coverUrl.value = upload.data.imageUrl
+
+  const persistOk = await persistDraft({ showSuccess: false })
+  uploadingCover.value = false
+  if (!persistOk) {
+    // 上传图片到 BE 已成功（短 URL 已落盘），但把短 URL 写回 draft 失败，
+    // 这种情况回滚 FE 字段，避免用户以为已保存，离开后再回来发现没绑上封面。
+    coverUrl.value = previousCover
+    return
+  }
+  ElMessage.success('封面已更新')
+}
+
+async function handleScreenshotChange(file: UploadFile) {
+  const raw = file.raw
+  if (!validateImageFile(raw)) {
+    return
+  }
+  if (!draftId.value) {
+    ElMessage.error('草稿尚未加载完成')
+    return
+  }
+  if (screenshotUrls.value.length >= MAX_SCREENSHOTS) {
+    ElMessage.warning(`最多 ${MAX_SCREENSHOTS} 张截图`)
+    return
+  }
+
+  uploadingScreenshot.value = true
+  const upload = await ruleApi.uploadRuleImage(draftId.value, raw)
+  if (!upload.success || !upload.data?.imageUrl) {
+    uploadingScreenshot.value = false
+    ElMessage.error(upload.message || '截图上传失败')
+    return
+  }
+  const previousList = [...screenshotUrls.value]
+  screenshotUrls.value = [...previousList, upload.data.imageUrl]
+
+  const persistOk = await persistDraft({ showSuccess: false })
+  uploadingScreenshot.value = false
+  if (!persistOk) {
+    screenshotUrls.value = previousList
+    return
+  }
+  ElMessage.success('截图已添加')
+}
+
+async function clearCover() {
+  if (!coverUrl.value || uploadingCover.value) return
+  const previous = coverUrl.value
+  coverUrl.value = ''
+  uploadingCover.value = true
+  const persistOk = await persistDraft({ showSuccess: false })
+  uploadingCover.value = false
+  if (!persistOk) {
+    coverUrl.value = previous
+    return
+  }
+  ElMessage.success('封面已移除')
+}
+
+async function removeScreenshot(index: number) {
+  if (uploadingScreenshot.value) return
+  const previous = [...screenshotUrls.value]
+  const next = [...previous]
+  next.splice(index, 1)
+  screenshotUrls.value = next
+  uploadingScreenshot.value = true
+  const persistOk = await persistDraft({ showSuccess: false })
+  uploadingScreenshot.value = false
+  if (!persistOk) {
+    screenshotUrls.value = previous
+    return
+  }
+  ElMessage.success('截图已移除')
+}
+
+interface PersistOptions {
+  showSuccess?: boolean
+}
+
+async function persistDraft(options: PersistOptions = {}): Promise<boolean> {
+  if (!draftId.value) {
+    ElMessage.error('草稿尚未加载完成')
+    return false
+  }
+  // updateDraft 需要 design 字段，沿用进入页面时拉到的 design 不动。
+  // PublishFormView 不修改规则结构，所以这里安全。
+  if (!cachedDesign) {
+    ElMessage.error('规则结构丢失，请回到创作中心重新编辑')
+    return false
+  }
+  const result = await ruleApi.updateDraft(draftId.value, {
+    name: ruleName.value,
+    playerCount: playerCount.value,
+    description: description.value,
+    design: cachedDesign as never,
+    introduction: introduction.value,
+    coverUrl: coverUrl.value,
+    screenshotUrls: screenshotUrls.value,
+  })
+  if (!result.success) {
+    ElMessage.error(result.message || '草稿保存失败')
+    return false
+  }
+  if (options.showSuccess) {
+    ElMessage.success('草稿已保存')
+  }
+  return true
+}
+
+async function saveDraft() {
+  if (saving.value) return
+  saving.value = true
+  await persistDraft({ showSuccess: true })
+  saving.value = false
+}
+
+async function submitForReview() {
+  if (submitting.value || submitDisabled.value) return
+  submitting.value = true
+  const persistOk = await persistDraft({ showSuccess: false })
+  if (!persistOk) {
+    submitting.value = false
+    return
+  }
+  const result = await ruleApi.submitReview(draftId.value)
+  submitting.value = false
+  if (!result.success || !result.data) {
+    ElMessage.error(result.message || '规则提交审核失败')
+    return
+  }
+  draftStatus.value = (result.data.status as RuleDraftStatus) || 'pendingReview'
+  rejectReason.value = ''
+  ElMessage.success('规则已提交审核，请等待审核员处理')
+}
+
+onMounted(() => {
+  void loadDraft()
+})
+</script>
+
+<style scoped>
+.publish-page {
+  min-height: 100%;
+  padding: 28px;
+  background: #f5f6fa;
+  color: #252633;
+  text-align: left;
+}
+
+.publish-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 16px;
+  padding: 22px 24px;
+  border: 1px solid #dfe3ec;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.publish-header h1 {
+  margin: 0;
+  font-size: 26px;
+}
+
+.rule-name {
+  margin: 6px 0 0;
+  color: #4a5063;
+}
+
+.header-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.reject-banner {
+  margin-bottom: 16px;
+  padding: 12px 16px;
+  border: 1px solid #f3c4c4;
+  border-radius: 8px;
+  background: #fdecec;
+  color: #b42323;
+  font-size: 14px;
+}
+
+.publish-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.4fr);
+  gap: 16px;
+}
+
+.card {
+  padding: 22px;
+  border: 1px solid #dfe3ec;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.card h2 {
+  margin: 0 0 6px;
+  font-size: 18px;
+}
+
+.muted {
+  color: #6b7180;
+  font-size: 13px;
+}
+
+.cover-card .cover-area {
+  display: grid;
+  grid-template-columns: 240px auto;
+  gap: 16px;
+  margin-top: 14px;
+  align-items: start;
+}
+
+.cover-preview {
+  width: 240px;
+  height: 140px;
+  border-radius: 8px;
+  border: 1px dashed #c8cdd9;
+  background: #f8f9fc;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  color: #8a90a0;
+}
+
+.cover-preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.cover-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: flex-start;
+}
+
+.text-btn {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: #b42323;
+}
+
+.text-btn:hover,
+.text-btn:focus {
+  background: transparent;
+  color: #8a1c1c;
+}
+
+.shots-card {
+  grid-column: 1 / -1;
+}
+
+.shots-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.shots-empty {
+  margin-top: 12px;
+}
+
+.shots-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 12px;
+  margin: 14px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.shot-item {
+  position: relative;
+  border: 1px solid #dfe3ec;
+  border-radius: 8px;
+  background: #fbfcfe;
+  overflow: hidden;
+}
+
+.shot-item img {
+  display: block;
+  width: 100%;
+  height: 110px;
+  object-fit: cover;
+}
+
+.shot-remove {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  border: 0;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.shot-remove:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+@media (max-width: 900px) {
+  .publish-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .cover-card .cover-area {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .cover-preview {
+    width: 100%;
+  }
+}
+</style>

--- a/src/views/RuleMarketDetailView.vue
+++ b/src/views/RuleMarketDetailView.vue
@@ -21,12 +21,12 @@
 
       <main class="detail-grid">
         <section class="screenshot-panel panel">
-          <img v-if="activeScreenshot" :src="activeScreenshot" :alt="rule.name">
+          <img v-if="coverImage" :src="resolveImageUrl(coverImage)" :alt="rule.name">
           <div v-else class="screenshot-placeholder">{{ rule.type }}</div>
         </section>
         <section class="intro-panel panel">
           <h2>玩法介绍</h2>
-          <p>{{ rule.introduction || rule.description }}</p>
+          <p class="intro-body">{{ rule.introduction || rule.description }}</p>
           <div class="action-row">
             <el-button class="market-btn" @click="router.push(`/rule-market/${encodeURIComponent(rule.id)}/rooms`)">搜索房间</el-button>
             <el-button class="market-btn" @click="quickCreateRoom">快速使用规则</el-button>
@@ -34,6 +34,29 @@
           </div>
         </section>
       </main>
+
+      <section v-if="screenshotList.length > 0" class="screenshots-panel panel">
+        <h2>规则截图</h2>
+        <el-carousel
+          v-if="screenshotList.length > 1"
+          :interval="5000"
+          height="360px"
+          indicator-position="outside"
+        >
+          <el-carousel-item
+            v-for="(shot, index) in screenshotList"
+            :key="shot + index"
+          >
+            <img :src="resolveImageUrl(shot)" :alt="`${rule.name} 截图 ${index + 1}`" class="screenshot-large">
+          </el-carousel-item>
+        </el-carousel>
+        <img
+          v-else
+          :src="resolveImageUrl(screenshotList[0])"
+          :alt="`${rule.name} 截图`"
+          class="screenshot-large screenshot-single"
+        >
+      </section>
 
       <section class="review-panel panel">
         <h2>评分与评论</h2>
@@ -82,6 +105,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { ElMessage } from 'element-plus'
 import type { UploadFile } from 'element-plus'
 import { marketApi, resolveDeveloperAvatar, type PublishedRuleDetail } from '../api/market'
+import { getApiUrl } from '../api/config'
 import { useRuleFork } from '../composables/useRuleFork'
 
 const route = useRoute()
@@ -104,7 +128,20 @@ function handleFork() {
 }
 
 const ruleId = computed(() => String(route.params.ruleId || ''))
-const activeScreenshot = computed(() => rule.value?.screenshots[0] || rule.value?.coverUrl || '')
+const screenshotList = computed(() => rule.value?.screenshots?.filter(Boolean) || [])
+const coverImage = computed(() => rule.value?.coverUrl || screenshotList.value[0] || '')
+
+/**
+ * BE 返回的图片 URL 形如 /static/rule-images/<uuid>.<ext>，是相对路径。
+ * 这里复用 getApiUrl，让 dev / prod 两套部署都能拼到正确的 BE 域名。
+ */
+function resolveImageUrl(url: string) {
+  if (!url) return ''
+  if (/^(https?:|data:)/i.test(url)) {
+    return url
+  }
+  return getApiUrl(url)
+}
 
 function formatDate(timestamp: number) {
   return new Date(timestamp).toLocaleString('zh-CN', {
@@ -333,6 +370,34 @@ onMounted(() => {
   color: #4a5063;
   line-height: 1.8;
   margin-bottom: 20px;
+}
+
+.intro-body {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.screenshots-panel {
+  margin-bottom: 16px;
+  padding: 22px;
+}
+
+.screenshots-panel h2 {
+  margin: 0 0 14px;
+  font-size: 20px;
+  letter-spacing: 0;
+}
+
+.screenshot-large {
+  width: 100%;
+  max-height: 360px;
+  object-fit: contain;
+  background: #0f1320;
+  border-radius: 6px;
+}
+
+.screenshot-single {
+  max-height: 480px;
 }
 
 .review-form {

--- a/src/views/RuleMarketHomeView.vue
+++ b/src/views/RuleMarketHomeView.vue
@@ -41,7 +41,7 @@
         @keydown.enter.prevent="openRule(rule.id)"
       >
         <div class="rule-cover">
-          <img v-if="rule.coverUrl" :src="rule.coverUrl" :alt="rule.name">
+          <img v-if="rule.coverUrl" :src="resolveImageUrl(rule.coverUrl)" :alt="rule.name">
           <span v-else>{{ rule.type }}</span>
         </div>
         <div class="rule-card-body">
@@ -80,6 +80,7 @@ import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { ElMessage } from 'element-plus'
 import { marketApi, resolveDeveloperAvatar, type PublishedRuleSummary } from '../api/market'
+import { getApiUrl } from '../api/config'
 import { useRuleFork } from '../composables/useRuleFork'
 
 const router = useRouter()
@@ -97,6 +98,15 @@ const ruleTypes = computed(() => Array.from(new Set(rules.value.map((rule) => ru
 
 function formatDate(timestamp: number) {
   return new Date(timestamp).toLocaleDateString('zh-CN')
+}
+
+// BE 返回的封面 URL 形如 /static/rule-images/<uuid>.<ext>，需要拼上 API 域。
+function resolveImageUrl(url: string) {
+  if (!url) return ''
+  if (/^(https?:|data:)/i.test(url)) {
+    return url
+  }
+  return getApiUrl(url)
 }
 
 async function loadRules() {

--- a/src/views/__tests__/PublishFormView.spec.ts
+++ b/src/views/__tests__/PublishFormView.spec.ts
@@ -1,0 +1,196 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ElMessage } from 'element-plus'
+import { ruleApi, type RuleDraftDetail } from '../../api/rule'
+import PublishFormView from '../PublishFormView.vue'
+
+const push = vi.fn()
+const replace = vi.fn()
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: { draftId: 'draft-1' } }),
+  useRouter: () => ({ push, replace }),
+}))
+
+vi.mock('../../api/rule', () => ({
+  ruleApi: {
+    getDraft: vi.fn(),
+    updateDraft: vi.fn(),
+    submitReview: vi.fn(),
+    uploadRuleImage: vi.fn(),
+  },
+}))
+
+vi.mock('../../api/config', () => ({
+  getApiUrl: (endpoint: string) => `http://test${endpoint}`,
+}))
+
+vi.mock('element-plus', async () => {
+  const actual = await vi.importActual<typeof import('element-plus')>('element-plus')
+  return {
+    ...actual,
+    ElMessage: {
+      success: vi.fn(),
+      error: vi.fn(),
+      warning: vi.fn(),
+      info: vi.fn(),
+    },
+  }
+})
+
+const baseDraft: RuleDraftDetail = {
+  id: 'draft-1',
+  name: '示例规则',
+  playerCount: 2,
+  description: '描述',
+  status: 'draft',
+  updatedAt: 0,
+  createdAt: 0,
+  introduction: '原始介绍',
+  coverUrl: '/static/rule-images/old-cover.png',
+  screenshotUrls: ['/static/rule-images/shot-a.png'],
+  design: { foo: 'bar' } as never,
+}
+
+const stubs = {
+  ElButton: {
+    inheritAttrs: false,
+    emits: ['click'],
+    props: ['loading', 'disabled', 'type'],
+    template: '<button type="button" :disabled="disabled || loading" @click="$emit(\'click\')"><slot /></button>',
+  },
+  ElSkeleton: { template: '<div class="skeleton" />' },
+  ElInput: {
+    props: ['modelValue', 'type'],
+    emits: ['update:modelValue'],
+    template:
+      '<textarea v-if="type === \'textarea\'" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />' +
+      '<input v-else :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+  },
+  ElUpload: {
+    props: ['onChange'],
+    template: '<div class="upload" @click="$emit(\'trigger\')"><slot /></div>',
+  },
+}
+
+function mountView() {
+  return mount(PublishFormView, { global: { stubs } })
+}
+
+function cloneDraft(overrides: Partial<RuleDraftDetail> = {}): RuleDraftDetail {
+  return { ...baseDraft, ...overrides }
+}
+
+describe('PublishFormView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(ruleApi.getDraft).mockResolvedValue({ success: true, data: cloneDraft() })
+    vi.mocked(ruleApi.updateDraft).mockResolvedValue({ success: true, data: { id: 'draft-1', updatedAt: 1 } })
+    vi.mocked(ruleApi.submitReview).mockResolvedValue({
+      success: true,
+      data: { id: 'draft-1', status: 'pendingReview', updatedAt: 2 },
+    })
+    vi.mocked(ruleApi.uploadRuleImage).mockResolvedValue({
+      success: true,
+      data: { imageUrl: '/static/rule-images/new.png' },
+    })
+  })
+
+  it('进入页面拉 draft 并把 introduction / coverUrl / screenshotUrls 渲染到表单', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(ruleApi.getDraft).toHaveBeenCalledWith('draft-1')
+    expect(wrapper.find('textarea').element.value).toBe('原始介绍')
+    expect(wrapper.find('.cover-preview img').attributes('src')).toContain('old-cover.png')
+    expect(wrapper.findAll('.shot-item')).toHaveLength(1)
+    expect(wrapper.text()).toContain('示例规则')
+  })
+
+  it('点"提交审核"先保存草稿再调 submitReview', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.find('textarea').setValue('新的介绍\n第二行')
+    const submitBtn = wrapper.findAll('button').find(btn => btn.text() === '提交审核')
+    expect(submitBtn).toBeDefined()
+    await submitBtn!.trigger('click')
+    await flushPromises()
+
+    expect(ruleApi.updateDraft).toHaveBeenCalled()
+    const payload = vi.mocked(ruleApi.updateDraft).mock.calls.at(-1)?.[1]
+    expect(payload?.introduction).toBe('新的介绍\n第二行')
+    expect(payload?.coverUrl).toBe('/static/rule-images/old-cover.png')
+    expect(payload?.screenshotUrls).toEqual(['/static/rule-images/shot-a.png'])
+    expect(ruleApi.submitReview).toHaveBeenCalledWith('draft-1')
+    expect(ElMessage.success).toHaveBeenCalledWith('规则已提交审核，请等待审核员处理')
+    // 按钮文案在 status 切到 pendingReview 后应变成"审核中"
+    expect(wrapper.findAll('button').some(btn => btn.text() === '审核中')).toBe(true)
+  })
+
+  it('上传封面成功后写入字段并 persist；持久化失败时回滚封面 URL', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    // 仅保存草稿应能命中 updateDraft
+    const saveBtn = wrapper.findAll('button').find(btn => btn.text() === '保存草稿')
+    await saveBtn!.trigger('click')
+    await flushPromises()
+    expect(ElMessage.success).toHaveBeenCalledWith('草稿已保存')
+
+    // 模拟封面上传时 persist 失败，触发回滚
+    vi.mocked(ruleApi.updateDraft).mockResolvedValueOnce({ success: false, message: '保存失败' })
+    const componentInstance = wrapper.vm as unknown as {
+      handleCoverChange: (file: { raw: File }) => Promise<void>
+      coverUrl: string
+    }
+    const fakeFile = new File(['x'], 'cover.png', { type: 'image/png' })
+    await componentInstance.handleCoverChange({ raw: fakeFile })
+    await flushPromises()
+
+    // upload 成功了但 persist 失败 → coverUrl 应被回滚到旧值
+    expect(ruleApi.uploadRuleImage).toHaveBeenCalledWith('draft-1', fakeFile)
+    expect(componentInstance.coverUrl).toBe('/static/rule-images/old-cover.png')
+    expect(ElMessage.error).toHaveBeenCalledWith('保存失败')
+  })
+
+  it('rejected 状态展示驳回原因提示条，按钮文案为"重新提交审核"', async () => {
+    vi.mocked(ruleApi.getDraft).mockResolvedValueOnce({
+      success: true,
+      data: cloneDraft({ status: 'rejected', rejectReason: '请补充示例图片' }),
+    })
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.find('.reject-banner').exists()).toBe(true)
+    expect(wrapper.find('.reject-banner').text()).toContain('请补充示例图片')
+    expect(wrapper.findAll('button').some(btn => btn.text() === '重新提交审核')).toBe(true)
+  })
+
+  it('截图上传成功后追加 URL；删除截图同步 persist 失败时回滚', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    const componentInstance = wrapper.vm as unknown as {
+      handleScreenshotChange: (file: { raw: File }) => Promise<void>
+      removeScreenshot: (index: number) => Promise<void>
+      screenshotUrls: string[]
+    }
+    const fakeFile = new File(['x'], 'shot.png', { type: 'image/png' })
+    await componentInstance.handleScreenshotChange({ raw: fakeFile })
+    await flushPromises()
+    expect(componentInstance.screenshotUrls).toEqual([
+      '/static/rule-images/shot-a.png',
+      '/static/rule-images/new.png',
+    ])
+
+    // 删除时 persist 失败 → 回滚到删除前
+    vi.mocked(ruleApi.updateDraft).mockResolvedValueOnce({ success: false, message: '保存失败' })
+    await componentInstance.removeScreenshot(0)
+    await flushPromises()
+    expect(componentInstance.screenshotUrls).toEqual([
+      '/static/rule-images/shot-a.png',
+      '/static/rule-images/new.png',
+    ])
+  })
+})

--- a/src/views/__tests__/RuleMarketDetailView.spec.ts
+++ b/src/views/__tests__/RuleMarketDetailView.spec.ts
@@ -79,6 +79,8 @@ const stubs = {
     template: '<textarea v-if="type === \'textarea\'" v-bind="$attrs" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" /><input v-else v-bind="$attrs" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
   },
   ElUpload: { template: '<div class="upload"><slot /></div>' },
+  ElCarousel: { template: '<div class="carousel"><slot /></div>' },
+  ElCarouselItem: { template: '<div class="carousel-item"><slot /></div>' },
 }
 
 function mountView() {


### PR DESCRIPTION
## Phase 2B
作者发布表单页 + 详情/列表渲染 meta。

### 新页 `/creation-center/:draftId/publish`
- 封面上传（单图，选完立即 POST `/drafts/{id}/images` 拿短 URL）
- 介绍文本框（12 行 textarea，详情页 pre-wrap 渲染保留换行 — 这次不加 markdown 库）
- 多张截图（≤10，缩略图列表，可单删）
- 底部按钮按 status 切：保存草稿 / 提交审核 / 更新上架规则 / 重新提交审核
- rejected 显示驳回原因

### CreationCenter
每行加 "发布规则 / 更新上架规则 / 重新提交审核" 按钮 → 跳新表单页。pendingReview 行禁用。

### api
- `RuleDraft*` 类型加 3 可选字段
- 新增 `uploadRuleImage(draftId, file)`（multipart）

### 详情页
- `resolveImageUrl` 拼 API base 给 /static 短 URL
- 顶部封面（fallback 到 type placeholder）
- introduction 用 `white-space: pre-wrap` 保留作者排版
- el-carousel 显示截图

### 列表
卡片 coverUrl 也走 resolveImageUrl。

## 测试
7 个新单测。136/136 全过，build clean。
