### PR TITLE
feat(market): admin review panel for moderating rule submissions

### DIFF
--- a/src/api/__tests__/admin.spec.ts
+++ b/src/api/__tests__/admin.spec.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { apiGet, apiPost } from '../request'
+import { adminApi } from '../admin'
+
+vi.mock('../request', () => ({
+  apiGet: vi.fn(),
+  apiPost: vi.fn(),
+}))
+
+describe('adminApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('listPending 走 GET /api/admin/rules/pending，并返回 BE 数组', async () => {
+    vi.mocked(apiGet).mockResolvedValue({
+      success: true,
+      data: [
+        {
+          draftId: 'd1',
+          name: '示例规则',
+          ownerId: 'u1',
+          ownerName: 'Alice',
+          playerCount: 2,
+          description: '',
+          updatedAt: 1700000000000,
+          design: { nodes: [] },
+        },
+      ],
+    })
+
+    const result = await adminApi.listPending()
+
+    expect(apiGet).toHaveBeenCalledWith('/api/admin/rules/pending', { useMock: false })
+    expect(result.success).toBe(true)
+    expect(result.data).toHaveLength(1)
+    expect(result.data?.[0]?.draftId).toBe('d1')
+  })
+
+  it('approve 走 POST /api/admin/rules/{id}/approve，并对 draftId 编码', async () => {
+    vi.mocked(apiPost).mockResolvedValue({
+      success: true,
+      data: { ruleId: 'r-1', version: 1, status: 'published' },
+    })
+
+    const result = await adminApi.approve('draft/with space')
+
+    expect(apiPost).toHaveBeenCalledWith(
+      '/api/admin/rules/draft%2Fwith%20space/approve',
+      {},
+      { useMock: false },
+    )
+    expect(result.success).toBe(true)
+    expect(result.data?.ruleId).toBe('r-1')
+  })
+
+  it('reject 走 POST /api/admin/rules/{id}/reject，body 携带 reason', async () => {
+    vi.mocked(apiPost).mockResolvedValue({
+      success: true,
+      data: { id: 'd1', status: 'rejected', updatedAt: 1 },
+    })
+
+    const result = await adminApi.reject('d1', '描述不清')
+
+    expect(apiPost).toHaveBeenCalledWith(
+      '/api/admin/rules/d1/reject',
+      { reason: '描述不清' },
+      { useMock: false },
+    )
+    expect(result.success).toBe(true)
+    expect(result.data?.status).toBe('rejected')
+  })
+})

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -1,0 +1,71 @@
+import { apiGet, apiPost } from './request'
+import type { ExportedRuleDesign } from '../types/ruleBuilder'
+
+/**
+ * 审核员视角下的待审草稿。BE `GET /api/admin/rules/pending` 直接返回此结构的数组。
+ * 备注：introduction / coverUrl / screenshotUrls 是 Phase 1B 新增字段，老草稿可能为空。
+ */
+export interface PendingReviewDraft {
+  draftId: string
+  name: string
+  ownerId: string
+  ownerName: string
+  playerCount: number
+  description: string
+  updatedAt: number
+  design: ExportedRuleDesign | unknown
+  introduction?: string
+  coverUrl?: string
+  screenshotUrls?: string[]
+}
+
+export interface ApproveResponse {
+  ruleId: string
+  version: number
+  status: string
+}
+
+export interface RejectResponse {
+  id: string
+  status: string
+  updatedAt: number
+}
+
+interface ApiResult<T = unknown> {
+  success: boolean
+  data?: T
+  message?: string
+}
+
+export const adminApi = {
+  /**
+   * 拉取所有待审核草稿。仅 admin 可调，BE 对非 admin 返 403。
+   */
+  async listPending(): Promise<ApiResult<PendingReviewDraft[]>> {
+    return apiGet<ApiResult<PendingReviewDraft[]>>('/api/admin/rules/pending', {
+      useMock: false,
+    })
+  },
+
+  /**
+   * 批准草稿发布。BE 返回新建的 ruleId / version / 状态。
+   */
+  async approve(draftId: string): Promise<ApiResult<ApproveResponse>> {
+    return apiPost<ApiResult<ApproveResponse>>(
+      `/api/admin/rules/${encodeURIComponent(draftId)}/approve`,
+      {},
+      { useMock: false },
+    )
+  },
+
+  /**
+   * 驳回草稿，必须带上原因（≤512 字）。
+   */
+  async reject(draftId: string, reason: string): Promise<ApiResult<RejectResponse>> {
+    return apiPost<ApiResult<RejectResponse>>(
+      `/api/admin/rules/${encodeURIComponent(draftId)}/reject`,
+      { reason },
+      { useMock: false },
+    )
+  },
+}

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -27,6 +27,15 @@
             <el-icon><User /></el-icon>
             <span>用户中心</span>
           </router-link>
+          <router-link
+            v-if="userStore.isAdmin"
+            to="/admin/rules-review"
+            class="nav-item"
+            exact-active-class="active"
+          >
+            <el-icon><Document /></el-icon>
+            <span>规则审核</span>
+          </router-link>
         </nav>
         <div class="sidebar-bottom">
           <div class="user-avatar">

--- a/src/layouts/__tests__/MainLayout.spec.ts
+++ b/src/layouts/__tests__/MainLayout.spec.ts
@@ -45,6 +45,7 @@ describe('MainLayout', () => {
             Shop: true,
             Brush: true,
             VideoPlay: true,
+            Document: true,
           },
         },
       })
@@ -73,6 +74,7 @@ describe('MainLayout', () => {
             Shop: true,
             Brush: true,
             VideoPlay: true,
+            Document: true,
           },
         },
       })
@@ -95,6 +97,7 @@ describe('MainLayout', () => {
             Shop: true,
             Brush: true,
             VideoPlay: true,
+            Document: true,
           },
         },
       })
@@ -127,6 +130,7 @@ describe('MainLayout', () => {
             Shop: true,
             Brush: true,
             VideoPlay: true,
+            Document: true,
           },
         },
       })
@@ -156,6 +160,7 @@ describe('MainLayout', () => {
             Shop: true,
             Brush: true,
             VideoPlay: true,
+            Document: true,
           },
         },
       })
@@ -185,6 +190,7 @@ describe('MainLayout', () => {
             Shop: true,
             Brush: true,
             VideoPlay: true,
+            Document: true,
           },
         },
       })
@@ -222,6 +228,7 @@ describe('MainLayout', () => {
             Shop: true,
             Brush: true,
             VideoPlay: true,
+            Document: true,
           },
         },
       })
@@ -238,6 +245,69 @@ describe('MainLayout', () => {
 
       expect(wrapper.find('.username').text()).toBe('updateduser')
       expect(wrapper.find('.user-email').text()).toBe('updated@mail.com')
+    })
+  })
+
+  describe('审核员入口可见性', () => {
+    const sharedStubs = {
+      'router-link': RouterLinkStub,
+      'router-view': true,
+      'el-icon': true,
+      House: true,
+      EditPen: true,
+      User: true,
+      Shop: true,
+      Brush: true,
+      VideoPlay: true,
+      Document: true,
+    }
+
+    it('role=admin 时显示规则审核入口并指向 /admin/rules-review', () => {
+      const userStore = useUserStore()
+      userStore.setUser({
+        id: '1',
+        username: 'adminuser',
+        email: 'admin@mail.com',
+        avatar: '',
+        role: 'admin',
+      })
+
+      const wrapper = mount(MainLayout, { global: { stubs: sharedStubs } })
+
+      expect(wrapper.text()).toContain('规则审核')
+      const adminLink = wrapper.findAllComponents(RouterLinkStub).find(link => link.props('to') === '/admin/rules-review')
+      expect(adminLink).toBeTruthy()
+    })
+
+    it('role=user 时不显示规则审核入口', () => {
+      const userStore = useUserStore()
+      userStore.setUser({
+        id: '1',
+        username: 'normaluser',
+        email: 'user@mail.com',
+        avatar: '',
+        role: 'user',
+      })
+
+      const wrapper = mount(MainLayout, { global: { stubs: sharedStubs } })
+
+      expect(wrapper.text()).not.toContain('规则审核')
+      const adminLink = wrapper.findAllComponents(RouterLinkStub).find(link => link.props('to') === '/admin/rules-review')
+      expect(adminLink).toBeFalsy()
+    })
+
+    it('默认 role 缺省视为普通用户，不显示规则审核入口', () => {
+      const userStore = useUserStore()
+      userStore.setUser({
+        id: '1',
+        username: 'noroleuser',
+        email: 'user@mail.com',
+        avatar: '',
+      })
+
+      const wrapper = mount(MainLayout, { global: { stubs: sharedStubs } })
+
+      expect(wrapper.text()).not.toContain('规则审核')
     })
   })
 })

--- a/src/router/__tests__/index.spec.ts
+++ b/src/router/__tests__/index.spec.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { ElMessage } from 'element-plus'
+import { useUserStore } from '../../stores/userStore'
+
+vi.mock('element-plus', async () => {
+  const actual = await vi.importActual<typeof import('element-plus')>('element-plus')
+  return {
+    ...actual,
+    ElMessage: {
+      success: vi.fn(),
+      error: vi.fn(),
+      warning: vi.fn(),
+      info: vi.fn(),
+    },
+  }
+})
+
+vi.mock('../../api/room', () => ({
+  roomApi: {
+    getCurrentRoom: vi.fn().mockResolvedValue({ success: false }),
+  },
+  getRoomEntryPath: () => '/',
+}))
+
+describe('router 守卫：/admin 命名空间', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    sessionStorage.clear()
+    setActivePinia(createPinia())
+    // 重置路由模块缓存，确保每次拿到的是新建的 router 实例
+    vi.resetModules()
+  })
+
+  it('未登录用户访问 /admin/rules-review 时被踢回 /user-info（更优先于 admin 检查）', async () => {
+    const { default: router } = await import('../index')
+    await router.push('/admin/rules-review')
+
+    expect(router.currentRoute.value.path).toBe('/user-info')
+  })
+
+  it('登录但非 admin 时被拒绝并提示，重定向到首页', async () => {
+    const { default: router } = await import('../index')
+    const userStore = useUserStore()
+    userStore.setUser({
+      id: '1',
+      username: 'normaluser',
+      email: 'u@mail.com',
+      avatar: '',
+      role: 'user',
+    })
+
+    await router.push('/admin/rules-review')
+
+    expect(router.currentRoute.value.path).toBe('/')
+    expect(ElMessage.error).toHaveBeenCalledWith('需要管理员权限')
+  })
+
+  it('admin 用户可正常进入 /admin/rules-review', async () => {
+    const { default: router } = await import('../index')
+    const userStore = useUserStore()
+    userStore.setUser({
+      id: '1',
+      username: 'adminuser',
+      email: 'admin@mail.com',
+      avatar: '',
+      role: 'admin',
+    })
+
+    await router.push('/admin/rules-review')
+
+    expect(router.currentRoute.value.path).toBe('/admin/rules-review')
+    expect(ElMessage.error).not.toHaveBeenCalled()
+  })
+})

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -18,6 +18,8 @@ import RuleMarketHomeView from '../views/RuleMarketHomeView.vue'
 import RuleMarketDetailView from '../views/RuleMarketDetailView.vue'
 import RuleDeveloperDetailView from '../views/RuleDeveloperDetailView.vue'
 import RuleRoomSearchView from '../views/RuleRoomSearchView.vue'
+import AdminRuleReviewView from '../views/AdminRuleReviewView.vue'
+import { ElMessage } from 'element-plus'
 import { roomApi, getRoomEntryPath } from '../api/room'
 import { useUserStore } from '../stores/userStore'
 
@@ -84,6 +86,10 @@ const routes: RouteRecordRaw[] = [
         component: { template: '<div>管理面板</div>' }
       },
       {
+        path: 'admin/rules-review',
+        component: AdminRuleReviewView
+      },
+      {
         path: 'create-room',
         component: CreateRoomView
       },
@@ -144,6 +150,13 @@ router.beforeEach(async (to) => {
 
   if (!userStore.isLoggedIn && !isPublicPath) {
     return { path: '/user-info' }
+  }
+
+  // /admin/* 是审核员专属，非 admin 进入时直接拦回首页并提示。
+  // 注意要放在登录检查之后：未登录用户已经被踢去 /user-info 了。
+  if (to.path.startsWith('/admin/') && !userStore.isAdmin) {
+    ElMessage.error('需要管理员权限')
+    return { path: '/' }
   }
 
   if (userStore.isLoggedIn && to.path === '/user-info') {

--- a/src/views/AdminRuleReviewView.vue
+++ b/src/views/AdminRuleReviewView.vue
@@ -1,0 +1,480 @@
+<template>
+  <div class="admin-review-page">
+    <header class="review-header">
+      <div>
+        <h1>规则审核</h1>
+        <p>查看作者提交的规则草稿，决定批准发布或驳回修改。</p>
+      </div>
+      <el-button :loading="loading" @click="loadPending">刷新</el-button>
+    </header>
+
+    <div v-if="loading && drafts.length === 0" class="empty-state">正在加载待审规则...</div>
+    <el-empty v-else-if="!loading && drafts.length === 0" description="暂无待审规则" />
+
+    <div v-else class="review-layout">
+      <aside class="pending-list">
+        <article
+          v-for="draft in drafts"
+          :key="draft.draftId"
+          :class="['pending-row', { active: selectedId === draft.draftId }]"
+          role="button"
+          tabindex="0"
+          @click="selectDraft(draft.draftId)"
+          @keydown.enter.prevent="selectDraft(draft.draftId)"
+        >
+          <strong>{{ draft.name || '未命名规则' }}</strong>
+          <p class="row-author">作者：{{ draft.ownerName || draft.ownerId }}</p>
+          <p class="row-meta">
+            <span>{{ draft.playerCount }} 人</span>
+            <span>{{ formatTime(draft.updatedAt) }}</span>
+          </p>
+        </article>
+      </aside>
+
+      <section class="detail-panel">
+        <el-empty v-if="!selectedDraft" description="请从左侧选择一条待审规则" />
+        <template v-else>
+          <header class="detail-header">
+            <div>
+              <h2>{{ selectedDraft.name || '未命名规则' }}</h2>
+              <p class="detail-author">
+                <span>作者：{{ selectedDraft.ownerName || selectedDraft.ownerId }}</span>
+                <span>玩家数：{{ selectedDraft.playerCount }}</span>
+                <span>提交时间：{{ formatTime(selectedDraft.updatedAt) }}</span>
+              </p>
+            </div>
+          </header>
+
+          <section class="detail-section">
+            <h3>规则简介</h3>
+            <p class="detail-description">{{ selectedDraft.description || '作者未填写说明' }}</p>
+            <pre v-if="selectedDraft.introduction" class="detail-introduction">{{ selectedDraft.introduction }}</pre>
+            <p v-else class="detail-introduction empty">作者未填写玩法介绍。</p>
+          </section>
+
+          <section v-if="selectedDraft.coverUrl" class="detail-section">
+            <h3>规则封面</h3>
+            <img class="detail-cover" :src="resolveImageUrl(selectedDraft.coverUrl)" alt="规则封面">
+          </section>
+
+          <section v-if="screenshots.length > 0" class="detail-section">
+            <h3>规则截图</h3>
+            <div class="screenshot-grid">
+              <img
+                v-for="(shot, index) in screenshots"
+                :key="shot + index"
+                :src="resolveImageUrl(shot)"
+                :alt="`截图 ${index + 1}`"
+                class="detail-screenshot"
+              >
+            </div>
+          </section>
+
+          <section class="detail-section design-section">
+            <button type="button" class="design-toggle" @click="designVisible = !designVisible">
+              {{ designVisible ? '收起规则 JSON' : '查看规则 JSON' }}
+            </button>
+            <pre v-if="designVisible" class="design-json"><code>{{ designJsonText }}</code></pre>
+          </section>
+
+          <footer class="detail-actions">
+            <el-button
+              type="success"
+              :loading="approving"
+              :disabled="rejecting"
+              @click="handleApprove"
+            >
+              批准发布
+            </el-button>
+            <el-button
+              type="danger"
+              :loading="rejecting"
+              :disabled="approving"
+              @click="handleReject"
+            >
+              驳回
+            </el-button>
+          </footer>
+        </template>
+      </section>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import { adminApi, type PendingReviewDraft } from '../api/admin'
+import { getApiUrl } from '../api/config'
+
+const loading = ref(false)
+const approving = ref(false)
+const rejecting = ref(false)
+const drafts = ref<PendingReviewDraft[]>([])
+const selectedId = ref<string>('')
+const designVisible = ref(false)
+
+const selectedDraft = computed(() =>
+  drafts.value.find(draft => draft.draftId === selectedId.value) || null,
+)
+
+const screenshots = computed(() =>
+  (selectedDraft.value?.screenshotUrls || []).filter(Boolean),
+)
+
+const designJsonText = computed(() => {
+  if (!selectedDraft.value) return ''
+  try {
+    return JSON.stringify(selectedDraft.value.design, null, 2)
+  } catch {
+    return String(selectedDraft.value.design)
+  }
+})
+
+function formatTime(timestamp: number) {
+  if (!timestamp) return '-'
+  return new Date(timestamp).toLocaleString('zh-CN', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+/**
+ * BE 返回的图片 URL 是相对路径（/static/rule-images/<uuid>.<ext>），
+ * 这里复用 getApiUrl 让 dev/prod 都能拼对域名；http/data URL 直接透传。
+ */
+function resolveImageUrl(url: string) {
+  if (!url) return ''
+  if (/^(https?:|data:)/i.test(url)) return url
+  return getApiUrl(url)
+}
+
+function selectDraft(draftId: string) {
+  selectedId.value = draftId
+  designVisible.value = false
+}
+
+async function loadPending() {
+  loading.value = true
+  const result = await adminApi.listPending()
+  loading.value = false
+
+  if (!result.success) {
+    ElMessage.error(result.message || '待审规则加载失败')
+    return
+  }
+
+  drafts.value = result.data || []
+  // 当前选中项若已被其他审核员处理，则清空右侧。
+  if (selectedId.value && !drafts.value.some(draft => draft.draftId === selectedId.value)) {
+    selectedId.value = ''
+  }
+}
+
+async function handleApprove() {
+  if (!selectedDraft.value) return
+  const draft = selectedDraft.value
+
+  try {
+    await ElMessageBox.confirm(
+      `确认批准规则“${draft.name || '未命名规则'}”发布吗？发布后将立即出现在规则市场。`,
+      '批准规则',
+      {
+        confirmButtonText: '批准',
+        cancelButtonText: '取消',
+        type: 'success',
+      },
+    )
+  } catch {
+    return
+  }
+
+  approving.value = true
+  const result = await adminApi.approve(draft.draftId)
+  approving.value = false
+
+  if (!result.success) {
+    ElMessage.error(result.message || '规则批准失败')
+    return
+  }
+
+  ElMessage.success('规则已批准发布')
+  selectedId.value = ''
+  await loadPending()
+}
+
+async function handleReject() {
+  if (!selectedDraft.value) return
+  const draft = selectedDraft.value
+
+  let reasonInput: string
+  try {
+    const result = await ElMessageBox.prompt(
+      `请填写驳回原因（必填，≤512 字）`,
+      `驳回规则：${draft.name || '未命名规则'}`,
+      {
+        confirmButtonText: '驳回',
+        cancelButtonText: '取消',
+        inputType: 'textarea',
+        inputValidator: (value: string) => {
+          const trimmed = (value || '').trim()
+          if (!trimmed) return '请填写驳回原因'
+          if (trimmed.length > 512) return '驳回原因不能超过 512 字'
+          return true
+        },
+      },
+    )
+    reasonInput = (result.value || '').trim()
+  } catch {
+    return
+  }
+
+  rejecting.value = true
+  const result = await adminApi.reject(draft.draftId, reasonInput)
+  rejecting.value = false
+
+  if (!result.success) {
+    ElMessage.error(result.message || '规则驳回失败')
+    return
+  }
+
+  ElMessage.success('规则已驳回')
+  selectedId.value = ''
+  await loadPending()
+}
+
+onMounted(() => {
+  void loadPending()
+})
+</script>
+
+<style scoped>
+.admin-review-page {
+  min-height: 100%;
+  padding: 28px;
+  background: #f5f6fa;
+  color: #252633;
+  text-align: left;
+}
+
+.review-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 20px;
+  padding: 22px 24px;
+  border: 1px solid #dfe3ec;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.review-header h1 {
+  margin: 0;
+  font-size: 26px;
+}
+
+.review-header p {
+  margin: 6px 0 0;
+  color: #4a5063;
+}
+
+.empty-state {
+  padding: 36px;
+  border: 1px solid #dfe3ec;
+  border-radius: 8px;
+  background: #fff;
+  text-align: center;
+  color: #4a5063;
+}
+
+.review-layout {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 16px;
+  align-items: start;
+}
+
+.pending-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: calc(100vh - 220px);
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.pending-row {
+  padding: 14px 16px;
+  border: 1px solid #dfe3ec;
+  border-radius: 8px;
+  background: #fff;
+  cursor: pointer;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.pending-row:hover {
+  border-color: #7b8cff;
+  box-shadow: 0 6px 18px rgba(42, 55, 120, 0.08);
+}
+
+.pending-row.active {
+  border-color: #4f63ff;
+  background: #eef1ff;
+}
+
+.pending-row strong {
+  display: block;
+  font-size: 15px;
+  margin-bottom: 4px;
+  word-break: break-word;
+}
+
+.row-author {
+  margin: 0 0 6px;
+  color: #4a5063;
+  font-size: 13px;
+}
+
+.row-meta {
+  margin: 0;
+  display: flex;
+  gap: 10px;
+  color: #6b7280;
+  font-size: 12px;
+}
+
+.detail-panel {
+  padding: 22px 24px;
+  border: 1px solid #dfe3ec;
+  border-radius: 8px;
+  background: #fff;
+  min-height: 320px;
+}
+
+.detail-header h2 {
+  margin: 0;
+  font-size: 22px;
+}
+
+.detail-author {
+  margin: 8px 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  color: #4a5063;
+  font-size: 13px;
+}
+
+.detail-section {
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px solid #eef0f6;
+}
+
+.detail-section h3 {
+  margin: 0 0 10px;
+  font-size: 15px;
+  color: #2d3142;
+}
+
+.detail-description {
+  margin: 0 0 10px;
+  color: #3a4050;
+  line-height: 1.55;
+}
+
+.detail-introduction {
+  margin: 0;
+  padding: 12px 14px;
+  border-radius: 6px;
+  background: #f5f6fa;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font: inherit;
+  color: #2d3142;
+  line-height: 1.55;
+}
+
+.detail-introduction.empty {
+  color: #9097a8;
+  background: transparent;
+  padding: 0;
+}
+
+.detail-cover {
+  max-width: 100%;
+  max-height: 280px;
+  border-radius: 6px;
+  border: 1px solid #dfe3ec;
+}
+
+.screenshot-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.detail-screenshot {
+  width: 160px;
+  height: 110px;
+  object-fit: cover;
+  border-radius: 6px;
+  border: 1px solid #dfe3ec;
+}
+
+.design-section {
+  text-align: left;
+}
+
+.design-toggle {
+  border: 1px solid #4f63ff;
+  background: #eef1ff;
+  color: #2d3fb5;
+  border-radius: 6px;
+  padding: 6px 12px;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.design-toggle:hover,
+.design-toggle:focus {
+  background: #dfe5ff;
+  outline: none;
+}
+
+.design-json {
+  margin-top: 10px;
+  padding: 12px 14px;
+  border-radius: 6px;
+  background: #1f2433;
+  color: #e8eaf6;
+  max-height: 380px;
+  overflow: auto;
+  font-family: 'Fira Code', Menlo, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.55;
+  white-space: pre;
+}
+
+.detail-actions {
+  margin-top: 24px;
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+@media (max-width: 920px) {
+  .review-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .pending-list {
+    max-height: none;
+  }
+}
+</style>

--- a/src/views/__tests__/AdminRuleReviewView.spec.ts
+++ b/src/views/__tests__/AdminRuleReviewView.spec.ts
@@ -1,0 +1,206 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import AdminRuleReviewView from '../AdminRuleReviewView.vue'
+import { adminApi, type PendingReviewDraft } from '../../api/admin'
+
+vi.mock('../../api/admin', () => ({
+  adminApi: {
+    listPending: vi.fn(),
+    approve: vi.fn(),
+    reject: vi.fn(),
+  },
+}))
+
+vi.mock('../../api/config', () => ({
+  getApiUrl: (endpoint: string) => `http://test${endpoint}`,
+}))
+
+vi.mock('element-plus', async () => {
+  const actual = await vi.importActual<typeof import('element-plus')>('element-plus')
+  return {
+    ...actual,
+    ElMessage: {
+      success: vi.fn(),
+      error: vi.fn(),
+      warning: vi.fn(),
+      info: vi.fn(),
+    },
+    ElMessageBox: {
+      confirm: vi.fn(),
+      prompt: vi.fn(),
+    },
+  }
+})
+
+const elButtonStub = {
+  inheritAttrs: false,
+  emits: ['click'],
+  props: ['loading', 'disabled', 'type'],
+  template:
+    '<button type="button" :disabled="disabled || loading" @click="$emit(\'click\')"><slot /></button>',
+}
+
+const stubs = {
+  ElButton: elButtonStub,
+  ElEmpty: {
+    props: ['description'],
+    template: '<div class="el-empty">{{ description }}</div>',
+  },
+}
+
+const pendingFixture: PendingReviewDraft[] = [
+  {
+    draftId: 'd-alpha',
+    name: 'Alpha 规则',
+    ownerId: 'u-1',
+    ownerName: 'Alice',
+    playerCount: 2,
+    description: '简短描述',
+    updatedAt: 1700000000000,
+    design: { nodes: [{ id: 'n1' }] },
+    introduction: '玩法 A',
+    coverUrl: '/static/rule-images/cover-alpha.png',
+    screenshotUrls: ['/static/rule-images/shot-1.png'],
+  },
+  {
+    draftId: 'd-beta',
+    name: 'Beta 规则',
+    ownerId: 'u-2',
+    ownerName: 'Bob',
+    playerCount: 4,
+    description: '另一个描述',
+    updatedAt: 1700000050000,
+    design: { nodes: [] },
+  },
+]
+
+function mountView() {
+  return mount(AdminRuleReviewView, { global: { stubs } })
+}
+
+describe('AdminRuleReviewView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(adminApi.listPending).mockResolvedValue({
+      success: true,
+      data: pendingFixture.map(item => ({ ...item })),
+    })
+    vi.mocked(adminApi.approve).mockResolvedValue({
+      success: true,
+      data: { ruleId: 'r-new', version: 1, status: 'published' },
+    })
+    vi.mocked(adminApi.reject).mockResolvedValue({
+      success: true,
+      data: { id: 'd-alpha', status: 'rejected', updatedAt: 1 },
+    })
+  })
+
+  it('挂载时拉取待审列表并渲染', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(adminApi.listPending).toHaveBeenCalledTimes(1)
+    const rows = wrapper.findAll('.pending-row')
+    expect(rows).toHaveLength(2)
+    expect(rows[0].text()).toContain('Alpha 规则')
+    expect(rows[0].text()).toContain('Alice')
+  })
+
+  it('待审列表为空时渲染暂无待审规则提示', async () => {
+    vi.mocked(adminApi.listPending).mockResolvedValueOnce({ success: true, data: [] })
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('暂无待审规则')
+    expect(wrapper.findAll('.pending-row')).toHaveLength(0)
+  })
+
+  it('选中条目后右侧详情区显示作者 / 介绍 / 截图 / design 折叠按钮', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.findAll('.pending-row')[0].trigger('click')
+    await flushPromises()
+
+    const detail = wrapper.find('.detail-panel')
+    expect(detail.text()).toContain('Alpha 规则')
+    expect(detail.text()).toContain('Alice')
+    expect(detail.text()).toContain('玩法 A')
+    expect(wrapper.find('.detail-cover').exists()).toBe(true)
+    expect(wrapper.find('.detail-cover').attributes('src')).toBe(
+      'http://test/static/rule-images/cover-alpha.png',
+    )
+    expect(wrapper.findAll('.detail-screenshot')).toHaveLength(1)
+
+    // design 默认折叠，点击切换显示
+    expect(wrapper.find('.design-json').exists()).toBe(false)
+    await wrapper.find('.design-toggle').trigger('click')
+    const jsonBlock = wrapper.find('.design-json')
+    expect(jsonBlock.exists()).toBe(true)
+    expect(jsonBlock.text()).toContain('"nodes"')
+  })
+
+  it('点击批准走 ElMessageBox.confirm，确认后调 approve 并刷新列表', async () => {
+    vi.mocked(ElMessageBox.confirm).mockResolvedValueOnce('confirm' as never)
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.findAll('.pending-row')[0].trigger('click')
+    await flushPromises()
+
+    const approveBtn = wrapper.findAll('.detail-actions button')[0]
+    await approveBtn.trigger('click')
+    await flushPromises()
+
+    expect(ElMessageBox.confirm).toHaveBeenCalledTimes(1)
+    expect(adminApi.approve).toHaveBeenCalledWith('d-alpha')
+    expect(ElMessage.success).toHaveBeenCalledWith('规则已批准发布')
+    // 批准后会重新拉一次列表（共 2 次）
+    expect(adminApi.listPending).toHaveBeenCalledTimes(2)
+  })
+
+  it('批准被用户取消时不调用 approve', async () => {
+    vi.mocked(ElMessageBox.confirm).mockRejectedValueOnce(new Error('cancel'))
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.findAll('.pending-row')[0].trigger('click')
+    await flushPromises()
+    await wrapper.findAll('.detail-actions button')[0].trigger('click')
+    await flushPromises()
+
+    expect(adminApi.approve).not.toHaveBeenCalled()
+  })
+
+  it('点击驳回走 ElMessageBox.prompt，输入原因后调 reject 并刷新', async () => {
+    vi.mocked(ElMessageBox.prompt).mockResolvedValueOnce({
+      value: '描述不清，请补充示例',
+      action: 'confirm',
+    } as never)
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.findAll('.pending-row')[0].trigger('click')
+    await flushPromises()
+
+    const rejectBtn = wrapper.findAll('.detail-actions button')[1]
+    await rejectBtn.trigger('click')
+    await flushPromises()
+
+    expect(ElMessageBox.prompt).toHaveBeenCalledTimes(1)
+    expect(adminApi.reject).toHaveBeenCalledWith('d-alpha', '描述不清，请补充示例')
+    expect(ElMessage.success).toHaveBeenCalledWith('规则已驳回')
+    expect(adminApi.listPending).toHaveBeenCalledTimes(2)
+  })
+
+  it('listPending 失败时通过 ElMessage.error 提示', async () => {
+    vi.mocked(adminApi.listPending).mockResolvedValueOnce({ success: false, message: '权限不足' })
+
+    mountView()
+    await flushPromises()
+
+    expect(ElMessage.error).toHaveBeenCalledWith('权限不足')
+  })
+})


### PR DESCRIPTION
## Phase 2C
审核员面板。

### 新页 `/admin/rules-review`
双栏：左 320px 待审列表，右详情 + 操作
- 右栏顶部：规则名 / 作者 / 玩家数 / 提交时间
- 中部：introduction (pre-wrap) + 封面 + 截图缩略
- design JSON 折叠区（默认收起，避免巨型 JSON 占屏）
- 底部：[批准] [驳回] 按钮
  - 批准 → ElMessageBox.confirm → approve → toast → 刷新
  - 驳回 → ElMessageBox.prompt 输入原因（必填，≤512）→ reject → toast → 刷新

### 权限
- 侧栏 "规则审核" 入口 `v-if="userStore.isAdmin"`
- `router.beforeEach` 守卫：`/admin/*` 非 admin 弹 ElMessage 后 push('/')；优先级在登录检查之后

### api
新建 `src/api/admin.ts`：listPending / approve / reject 三个方法

### 测试
16 个新单测（admin api 3 + view 7 + router 3 + layout 3）。152/152 全过。
