### PR TITLE
feat(market): admin can open a draft visually in readonly mode

### DIFF
--- a/src/api/__tests__/admin.spec.ts
+++ b/src/api/__tests__/admin.spec.ts
@@ -70,4 +70,39 @@ describe('adminApi', () => {
     expect(result.success).toBe(true)
     expect(result.data?.status).toBe('rejected')
   })
+
+  it('getDraft 走 GET /api/admin/rules/drafts/{id}，并返回完整草稿', async () => {
+    vi.mocked(apiGet).mockResolvedValue({
+      success: true,
+      data: {
+        id: 'd-preview',
+        name: '示例规则',
+        playerCount: 2,
+        description: '简介',
+        status: 'pendingReview',
+        updatedAt: 1700000000000,
+        createdAt: 1699999999000,
+        ownerId: 'u-1',
+        design: { classes: {}, cardsets: {}, cardset_comparisons: {}, match_flow: {}, end_flow: {} },
+      },
+    })
+
+    const result = await adminApi.getDraft('d-preview')
+
+    expect(apiGet).toHaveBeenCalledWith('/api/admin/rules/drafts/d-preview', { useMock: false })
+    expect(result.success).toBe(true)
+    expect(result.data?.id).toBe('d-preview')
+    expect(result.data?.design).toBeDefined()
+  })
+
+  it('getDraft 对包含特殊字符的 draftId 做 URL 编码', async () => {
+    vi.mocked(apiGet).mockResolvedValue({ success: true, data: undefined as never })
+
+    await adminApi.getDraft('draft/with space')
+
+    expect(apiGet).toHaveBeenCalledWith(
+      '/api/admin/rules/drafts/draft%2Fwith%20space',
+      { useMock: false },
+    )
+  })
 })

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -1,5 +1,6 @@
 import { apiGet, apiPost } from './request'
 import type { ExportedRuleDesign } from '../types/ruleBuilder'
+import type { RuleDraftDetail } from './rule'
 
 /**
  * 审核员视角下的待审草稿。BE `GET /api/admin/rules/pending` 直接返回此结构的数组。
@@ -45,6 +46,18 @@ export const adminApi = {
     return apiGet<ApiResult<PendingReviewDraft[]>>('/api/admin/rules/pending', {
       useMock: false,
     })
+  },
+
+  /**
+   * 拉取单个草稿的完整结构（含 design / status / owner_id 等），供审核员侧的可视化预览使用。
+   * 对应 BE `GET /api/admin/rules/drafts/{id}`，仅 admin 可调。
+   * 复用 ruleApi.getDraft 的 schema（`RuleDraftDetail`），方便后续 RuleBuilderView 共用 importRuleDesign。
+   */
+  async getDraft(draftId: string): Promise<ApiResult<RuleDraftDetail>> {
+    return apiGet<ApiResult<RuleDraftDetail>>(
+      `/api/admin/rules/drafts/${encodeURIComponent(draftId)}`,
+      { useMock: false },
+    )
   },
 
   /**

--- a/src/components/rule-builder/RuleFlowCanvas.vue
+++ b/src/components/rule-builder/RuleFlowCanvas.vue
@@ -6,8 +6,8 @@
         <p>{{ subtitle }}</p>
       </div>
       <div class="toolbar-actions">
-        <el-button size="small" @click="$emit('auto-layout')">整理布局</el-button>
-        <el-button size="small" :disabled="!canDeleteSelected" @click="$emit('delete-selected')">删除节点</el-button>
+        <el-button v-if="!readonly" size="small" @click="$emit('auto-layout')">整理布局</el-button>
+        <el-button v-if="!readonly" size="small" :disabled="!canDeleteSelected" @click="$emit('delete-selected')">删除节点</el-button>
         <el-button class="fullscreen-btn" size="small" @click="$emit('toggle-fullscreen')">
           <el-icon>
             <FullScreen v-if="!isFullscreen" />
@@ -24,7 +24,10 @@
       v-model:edges="localEdges"
       class="rule-flow"
       :default-viewport="{ x: 80, y: 60, zoom: 0.9 }"
-      :nodes-draggable="true"
+      :nodes-draggable="!readonly"
+      :nodes-connectable="!readonly"
+      :elements-selectable="!readonly"
+      :delete-key-code="readonly ? null : 'Backspace'"
       @connect="handleConnect"
       @node-click="handleNodeClick"
       @pane-click="$emit('select-node', null)"
@@ -56,6 +59,7 @@ const props = defineProps<{
   edges: RuleEdgeDraft[]
   selectedNodeId: string | null
   isFullscreen: boolean
+  readonly?: boolean
 }>()
 
 const emit = defineEmits<{

--- a/src/router/__tests__/index.spec.ts
+++ b/src/router/__tests__/index.spec.ts
@@ -73,4 +73,46 @@ describe('router 守卫：/admin 命名空间', () => {
     expect(router.currentRoute.value.path).toBe('/admin/rules-review')
     expect(ElMessage.error).not.toHaveBeenCalled()
   })
+
+  it('未登录访问 /admin/rules-review/preview/:draftId 被踢回 /user-info', async () => {
+    const { default: router } = await import('../index')
+    await router.push('/admin/rules-review/preview/d-preview')
+
+    expect(router.currentRoute.value.path).toBe('/user-info')
+  })
+
+  it('非 admin 访问 /admin/rules-review/preview/:draftId 被拦回首页', async () => {
+    const { default: router } = await import('../index')
+    const userStore = useUserStore()
+    userStore.setUser({
+      id: '1',
+      username: 'normaluser',
+      email: 'u@mail.com',
+      avatar: '',
+      role: 'user',
+    })
+
+    await router.push('/admin/rules-review/preview/d-preview')
+
+    expect(router.currentRoute.value.path).toBe('/')
+    expect(ElMessage.error).toHaveBeenCalledWith('需要管理员权限')
+  })
+
+  it('admin 可正常进入 /admin/rules-review/preview/:draftId', async () => {
+    const { default: router } = await import('../index')
+    const userStore = useUserStore()
+    userStore.setUser({
+      id: '1',
+      username: 'adminuser',
+      email: 'admin@mail.com',
+      avatar: '',
+      role: 'admin',
+    })
+
+    await router.push('/admin/rules-review/preview/d-preview')
+
+    expect(router.currentRoute.value.path).toBe('/admin/rules-review/preview/d-preview')
+    expect(router.currentRoute.value.params.draftId).toBe('d-preview')
+    expect(ElMessage.error).not.toHaveBeenCalled()
+  })
 })

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -90,6 +90,12 @@ const routes: RouteRecordRaw[] = [
         component: AdminRuleReviewView
       },
       {
+        // 审核员的可视化预览模式：与作者编辑共用 RuleBuilderView 组件，由组件内部根据 route.path 切到 readonly。
+        // 也走 /admin/* 守卫，非 admin 会被自动拦回首页。
+        path: 'admin/rules-review/preview/:draftId',
+        component: RuleBuilderView
+      },
+      {
         path: 'create-room',
         component: CreateRoomView
       },

--- a/src/views/AdminRuleReviewView.vue
+++ b/src/views/AdminRuleReviewView.vue
@@ -43,6 +43,9 @@
                 <span>提交时间：{{ formatTime(selectedDraft.updatedAt) }}</span>
               </p>
             </div>
+            <div class="detail-header-actions">
+              <el-button type="primary" plain @click="openVisualPreview">可视化预览</el-button>
+            </div>
           </header>
 
           <section class="detail-section">
@@ -103,10 +106,12 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { adminApi, type PendingReviewDraft } from '../api/admin'
 import { getApiUrl } from '../api/config'
 
+const router = useRouter()
 const loading = ref(false)
 const approving = ref(false)
 const rejecting = ref(false)
@@ -155,6 +160,17 @@ function resolveImageUrl(url: string) {
 function selectDraft(draftId: string) {
   selectedId.value = draftId
   designVisible.value = false
+}
+
+/**
+ * 在新标签页打开 RuleBuilderView 的只读预览。
+ * 用 router.resolve 而非直接拼字符串，方便测试用 mock router.resolve 验证调用，并保留 history mode 的 base。
+ * window.open 用 noopener,noreferrer 切断 opener，新窗不能 navigate 回这里。
+ */
+function openVisualPreview() {
+  if (!selectedDraft.value) return
+  const url = router.resolve(`/admin/rules-review/preview/${selectedDraft.value.draftId}`).href
+  window.open(url, '_blank', 'noopener,noreferrer')
 }
 
 async function loadPending() {
@@ -355,9 +371,20 @@ onMounted(() => {
   min-height: 320px;
 }
 
+.detail-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
 .detail-header h2 {
   margin: 0;
   font-size: 22px;
+}
+
+.detail-header-actions {
+  flex-shrink: 0;
 }
 
 .detail-author {

--- a/src/views/RuleBuilderView.vue
+++ b/src/views/RuleBuilderView.vue
@@ -1,17 +1,21 @@
 <template>
-  <div class="rule-builder-page">
+  <div class="rule-builder-page" :class="{ 'readonly-mode': isReadonly }">
+    <div v-if="isReadonly" class="readonly-banner">
+      只读预览模式 · 由审核员打开
+    </div>
     <header class="builder-header">
       <div>
         <h1>规则构建</h1>
         <p>{{ design.info.name }} · {{ design.info.playerCount }} 人</p>
       </div>
       <div class="header-actions">
-        <el-button @click="backToCenter">返回列表</el-button>
+        <el-button @click="backToCenter">{{ isReadonly ? '返回审核面板' : '返回列表' }}</el-button>
         <el-button @click="openTutorial">教程</el-button>
-        <el-button @click="openJsonImport">导入 JSON</el-button>
+        <el-button v-if="!isReadonly" @click="openJsonImport">导入 JSON</el-button>
         <el-button @click="showJson = !showJson">{{ showJson ? '隐藏 JSON' : '显示 JSON' }}</el-button>
-        <el-button type="primary" @click="saveDesign">保存草稿</el-button>
+        <el-button v-if="!isReadonly" type="primary" @click="saveDesign">保存草稿</el-button>
         <el-button
+          v-if="!isReadonly"
           type="success"
           :disabled="publishButtonDisabled"
           :loading="submitting"
@@ -20,7 +24,7 @@
           {{ publishButtonLabel }}
         </el-button>
         <span
-          v-if="draftStatus === 'rejected' && rejectReason"
+          v-if="!isReadonly && draftStatus === 'rejected' && rejectReason"
           class="reject-reason-inline"
         >
           驳回原因：{{ rejectReason }}
@@ -114,6 +118,7 @@
         :edges="activeGraph.edges"
         :selected-node-id="selectedNodeId"
         :is-fullscreen="isFlowFullscreen"
+        :readonly="isReadonly"
         @update:nodes="updateNodes"
         @update:edges="updateEdges"
         @select-node="selectedNodeId = $event"
@@ -163,6 +168,7 @@ import RuleJsonPreview from '../components/rule-builder/RuleJsonPreview.vue'
 import RulePropertyPanel from '../components/rule-builder/RulePropertyPanel.vue'
 import RuleStructurePanel from '../components/rule-builder/RuleStructurePanel.vue'
 import { ruleApi } from '../api'
+import { adminApi } from '../api/admin'
 import type { RuleDraftStatus } from '../api/rule'
 import type { ComponentTemplate, FlowGraphDraft, FlowScope, MethodDraft, RuleEdgeDraft, RuleNodeDraft } from '../types/ruleBuilder'
 import {
@@ -202,6 +208,13 @@ const jsonImportText = ref('')
 const flowCanvasRef = ref<InstanceType<typeof RuleFlowCanvas> | null>(null)
 const builderMainRef = ref<HTMLElement | null>(null)
 const isFlowFullscreen = ref(false)
+
+/**
+ * 审核员可视化预览：路由命中 /admin/rules-review/preview/:draftId 时进入只读模式。
+ * 只读下隐藏「保存草稿/提交审核/导入 JSON」并屏蔽画布编辑（见 RuleFlowCanvas 的 readonly prop +
+ * `.readonly-mode` 下 pointer-events: none），剩余 workspace tab / JSON 预览仍可浏览。
+ */
+const isReadonly = computed(() => route.path.startsWith('/admin/rules-review/preview/'))
 
 const workspaces: { key: WorkspaceKey; label: string }[] = [
   { key: 'structure', label: '基础与牌型' },
@@ -814,10 +827,14 @@ const loadDraftFromRoute = async () => {
     return
   }
 
-  const result = await ruleApi.getDraft(routeDraftId)
+  // 审核员预览走 adminApi（admin only 接口），作者编辑走 ruleApi（作者本人才能读）。
+  // 两者返回 schema 一致（RuleDraftDetail），后续 importRuleDesign 共用。
+  const result = isReadonly.value
+    ? await adminApi.getDraft(routeDraftId)
+    : await ruleApi.getDraft(routeDraftId)
   if (!result.success || !result.data) {
     ElMessage.error(result.message || '规则草稿加载失败')
-    await router.replace('/creation-center')
+    await router.replace(isReadonly.value ? '/admin/rules-review' : '/creation-center')
     return
   }
 
@@ -940,7 +957,7 @@ const publishButtonDisabled = computed(() => {
 })
 
 const backToCenter = () => {
-  void router.push('/creation-center')
+  void router.push(isReadonly.value ? '/admin/rules-review' : '/creation-center')
 }
 
 const TUTORIAL_URL = 'https://buaa-iset.github.io/WildCard_Docs/tutorials/rule-builder-overview/'
@@ -959,6 +976,43 @@ const openTutorial = () => {
   color: #252633;
   overflow: hidden;
   text-align: left;
+}
+
+.rule-builder-page.readonly-mode {
+  grid-template-rows: auto auto auto 1fr;
+}
+
+/*
+ * 审核员只读预览：屏蔽工作区内所有表单元素 / 按钮，避免审核员误改属性面板 / 结构面板。
+ * 仅作用于 .builder-main 内部，header 上的「返回 / 教程 / 显示 JSON」按钮以及画布工具栏
+ * 的「整理布局 / 全屏」按钮位于 .builder-main 之外或本身不会改 design，保留可点。
+ *
+ * 拖拽 / 连线 / 删除节点等 Vue Flow 内部编辑动作另外通过 RuleFlowCanvas 的 readonly prop 关掉
+ * （nodesDraggable / nodesConnectable / elementsSelectable / deleteKeyCode）。
+ */
+.readonly-mode :deep(.builder-main input),
+.readonly-mode :deep(.builder-main textarea),
+.readonly-mode :deep(.builder-main button),
+.readonly-mode :deep(.builder-main .el-input__inner),
+.readonly-mode :deep(.builder-main .el-select),
+.readonly-mode :deep(.builder-main .el-button) {
+  pointer-events: none;
+}
+
+/* 画布工具栏按钮（整理布局 / 全屏）不属于编辑动作，恢复点击。 */
+.readonly-mode :deep(.builder-main .canvas-toolbar .el-button),
+.readonly-mode :deep(.builder-main .canvas-toolbar button) {
+  pointer-events: auto;
+}
+
+.readonly-banner {
+  padding: 10px 28px;
+  background: linear-gradient(90deg, #fff7e6 0%, #ffe9c2 100%);
+  border-bottom: 1px solid #f4c477;
+  color: #8a5a00;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.4px;
 }
 
 .builder-header {

--- a/src/views/__tests__/AdminRuleReviewView.spec.ts
+++ b/src/views/__tests__/AdminRuleReviewView.spec.ts
@@ -16,6 +16,20 @@ vi.mock('../../api/config', () => ({
   getApiUrl: (endpoint: string) => `http://test${endpoint}`,
 }))
 
+const resolveMock = vi.fn((path: string) => ({ href: path }))
+
+vi.mock('vue-router', async () => {
+  const actual = await vi.importActual<typeof import('vue-router')>('vue-router')
+  return {
+    ...actual,
+    useRouter: () => ({
+      resolve: resolveMock,
+      push: vi.fn(),
+      replace: vi.fn(),
+    }),
+  }
+})
+
 vi.mock('element-plus', async () => {
   const actual = await vi.importActual<typeof import('element-plus')>('element-plus')
   return {
@@ -202,5 +216,32 @@ describe('AdminRuleReviewView', () => {
     await flushPromises()
 
     expect(ElMessage.error).toHaveBeenCalledWith('权限不足')
+  })
+
+  it('点击"可视化预览"按钮在新窗打开 RuleBuilderView 只读预览', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null as never)
+    resolveMock.mockClear()
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.findAll('.pending-row')[0].trigger('click')
+    await flushPromises()
+
+    const previewBtn = wrapper
+      .findAll('.detail-header-actions button')
+      .find(btn => btn.text().includes('可视化预览'))
+    expect(previewBtn).toBeTruthy()
+    await previewBtn!.trigger('click')
+
+    expect(resolveMock).toHaveBeenCalledWith('/admin/rules-review/preview/d-alpha')
+    expect(openSpy).toHaveBeenCalledTimes(1)
+    expect(openSpy).toHaveBeenCalledWith(
+      '/admin/rules-review/preview/d-alpha',
+      '_blank',
+      'noopener,noreferrer',
+    )
+
+    openSpy.mockRestore()
   })
 })

--- a/src/views/__tests__/RuleBuilderView.spec.ts
+++ b/src/views/__tests__/RuleBuilderView.spec.ts
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import RuleBuilderView from '../RuleBuilderView.vue'
 import {
@@ -21,6 +21,18 @@ vi.mock('../api/rule', () => ({
   },
 }))
 
+const adminGetDraftMock = vi.fn()
+vi.mock('../../api/admin', () => ({
+  adminApi: {
+    getDraft: (...args: unknown[]) => adminGetDraftMock(...args),
+  },
+}))
+
+const routeMock = {
+  params: {} as Record<string, string>,
+  path: '/creation-center',
+}
+
 vi.mock('vue-router', async () => {
   const actual = await vi.importActual<typeof import('vue-router')>('vue-router')
   return {
@@ -29,9 +41,7 @@ vi.mock('vue-router', async () => {
       push: vi.fn(),
       replace: vi.fn(),
     }),
-    useRoute: () => ({
-      params: {},
-    }),
+    useRoute: () => routeMock,
   }
 })
 
@@ -51,6 +61,10 @@ vi.mock('element-plus', async () => {
 describe('RuleBuilderView.vue', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // 默认回到作者编辑路由，readonly 用例自行覆盖
+    routeMock.params = {}
+    routeMock.path = '/creation-center'
+    adminGetDraftMock.mockReset()
   })
 
   describe('页面渲染', () => {
@@ -311,6 +325,108 @@ describe('RuleBuilderView.vue', () => {
       expect(exportedAgain['1'].position).toEqual(sourceFlow['1'].position)
       expect(exportedAgain['2'].position).toEqual(sourceFlow['2'].position)
       expect(exportedAgain['3'].position).toEqual(sourceFlow['3'].position)
+    })
+  })
+
+  describe('审核员只读预览模式', () => {
+    const emptyDesignPayload = {
+      classes: {},
+      cardsets: {},
+      cardset_comparisons: {},
+      match_flow: {},
+      end_flow: {},
+    }
+
+    const previewStubs = {
+      'el-button': { template: '<button class="el-button"><slot /></button>' },
+      'el-dialog': true,
+      'el-input': true,
+      'rule-structure-panel': true,
+      'rule-component-palette': true,
+      'rule-flow-canvas': true,
+      'rule-property-panel': true,
+      'rule-json-preview': true,
+    }
+
+    function enterPreviewRoute() {
+      routeMock.params = { draftId: 'd-preview' }
+      routeMock.path = '/admin/rules-review/preview/d-preview'
+    }
+
+    it('命中 preview 路由时通过 adminApi.getDraft 加载草稿', async () => {
+      enterPreviewRoute()
+      adminGetDraftMock.mockResolvedValueOnce({
+        success: true,
+        data: {
+          id: 'd-preview',
+          name: 'Preview 规则',
+          playerCount: 3,
+          description: '简介',
+          status: 'pendingReview',
+          updatedAt: 0,
+          createdAt: 0,
+          design: emptyDesignPayload,
+        },
+      })
+
+      mount(RuleBuilderView, { global: { stubs: previewStubs } })
+      await flushPromises()
+
+      expect(adminGetDraftMock).toHaveBeenCalledWith('d-preview')
+    })
+
+    it('readonly 模式隐藏「保存草稿」「提交审核」「导入 JSON」按钮，且根节点带 readonly-mode class', async () => {
+      enterPreviewRoute()
+      adminGetDraftMock.mockResolvedValueOnce({
+        success: true,
+        data: {
+          id: 'd-preview',
+          name: 'Preview 规则',
+          playerCount: 3,
+          description: '',
+          status: 'pendingReview',
+          updatedAt: 0,
+          createdAt: 0,
+          design: emptyDesignPayload,
+        },
+      })
+
+      const wrapper = mount(RuleBuilderView, { global: { stubs: previewStubs } })
+      await flushPromises()
+
+      expect(wrapper.find('.rule-builder-page').classes()).toContain('readonly-mode')
+
+      const buttonTexts = wrapper.findAll('.header-actions .el-button').map(btn => btn.text())
+      expect(buttonTexts).not.toContain('保存草稿')
+      expect(buttonTexts).not.toContain('提交审核')
+      expect(buttonTexts).not.toContain('导入 JSON')
+      expect(buttonTexts).toContain('返回审核面板')
+      expect(buttonTexts).toContain('教程')
+    })
+
+    it('readonly 模式显示"只读预览模式"提示条', async () => {
+      enterPreviewRoute()
+      adminGetDraftMock.mockResolvedValueOnce({
+        success: true,
+        data: {
+          id: 'd-preview',
+          name: 'Preview 规则',
+          playerCount: 3,
+          description: '',
+          status: 'pendingReview',
+          updatedAt: 0,
+          createdAt: 0,
+          design: emptyDesignPayload,
+        },
+      })
+
+      const wrapper = mount(RuleBuilderView, { global: { stubs: previewStubs } })
+      await flushPromises()
+
+      const banner = wrapper.find('.readonly-banner')
+      expect(banner.exists()).toBe(true)
+      expect(banner.text()).toContain('只读预览模式')
+      expect(banner.text()).toContain('审核员')
     })
   })
 })


### PR DESCRIPTION
## 功能
审核员在面板看 design JSON 体验差。给 RuleBuilderView 加 readonly 模式，admin 在审核员面板点「可视化预览」 → 新标签页打开同一画布的只读版本。

## 入口
审核员面板右栏顶部新增「可视化预览」按钮 → `window.open('/admin/rules-review/preview/{draftId}', '_blank')`

## readonly 实现（三重防御）
1. **Vue Flow flags**：`nodesDraggable=false` / `nodesConnectable=false` / `elementsSelectable=false` / `deleteKeyCode=null` 关掉画布原生编辑
2. **CSS `pointer-events: none`**：`.readonly-mode :deep(input/textarea/button/el-*)` 全屏蔽
3. **`v-if` 删按钮**：保存草稿 / 提交审核 / 导入 JSON / 工具栏的可写按钮直接不渲染

## API
新增 `adminApi.getDraft(draftId)` → `GET /api/admin/rules/drafts/{id}`，复用 BE PR #134。

## 路由
- `/admin/rules-review/preview/:draftId` → RuleBuilderView
- 复用现有 `/admin/*` 守卫，admin 才能进

## UX
顶部加橙色 banner："只读预览模式 · 由审核员打开"
"返回列表" 改为 "返回审核面板"，跳回 `/admin/rules-review`

## 测试
8 个新单测：admin api 2 / AdminReview 1 / RuleBuilder 3 / router guard 3。161/161 全过，build 通过。
