### PR TITLE
fix(admin): show visual preview inside an in-page dialog

### DIFF
--- a/src/views/AdminRuleReviewView.vue
+++ b/src/views/AdminRuleReviewView.vue
@@ -101,6 +101,26 @@
         </template>
       </section>
     </div>
+
+    <el-dialog
+      v-model="previewVisible"
+      title="可视化预览"
+      width="92%"
+      top="3vh"
+      class="preview-dialog"
+      :close-on-click-modal="false"
+      :close-on-press-escape="true"
+      append-to-body
+      destroy-on-close
+      @close="closePreview"
+    >
+      <iframe
+        v-if="previewUrl"
+        :src="previewUrl"
+        class="preview-iframe"
+        title="规则可视化预览"
+      ></iframe>
+    </el-dialog>
   </div>
 </template>
 
@@ -118,6 +138,8 @@ const rejecting = ref(false)
 const drafts = ref<PendingReviewDraft[]>([])
 const selectedId = ref<string>('')
 const designVisible = ref(false)
+const previewVisible = ref(false)
+const previewUrl = ref('')
 
 const selectedDraft = computed(() =>
   drafts.value.find(draft => draft.draftId === selectedId.value) || null,
@@ -169,8 +191,13 @@ function selectDraft(draftId: string) {
  */
 function openVisualPreview() {
   if (!selectedDraft.value) return
-  const url = router.resolve(`/admin/rules-review/preview/${selectedDraft.value.draftId}`).href
-  window.open(url, '_blank', 'noopener,noreferrer')
+  previewUrl.value = router.resolve(`/admin/rules-review/preview/${selectedDraft.value.draftId}`).href
+  previewVisible.value = true
+}
+
+function closePreview() {
+  previewVisible.value = false
+  previewUrl.value = ''
 }
 
 async function loadPending() {
@@ -503,5 +530,18 @@ onMounted(() => {
   .pending-list {
     max-height: none;
   }
+}
+
+.preview-dialog :deep(.el-dialog__body) {
+  padding: 0;
+  height: calc(100vh - 12vh);
+  overflow: hidden;
+}
+
+.preview-iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  display: block;
 }
 </style>

--- a/src/views/__tests__/AdminRuleReviewView.spec.ts
+++ b/src/views/__tests__/AdminRuleReviewView.spec.ts
@@ -218,8 +218,7 @@ describe('AdminRuleReviewView', () => {
     expect(ElMessage.error).toHaveBeenCalledWith('权限不足')
   })
 
-  it('点击"可视化预览"按钮在新窗打开 RuleBuilderView 只读预览', async () => {
-    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null as never)
+  it('点击"可视化预览"按钮弹出同源 iframe dialog', async () => {
     resolveMock.mockClear()
 
     const wrapper = mountView()
@@ -234,14 +233,11 @@ describe('AdminRuleReviewView', () => {
     expect(previewBtn).toBeTruthy()
     await previewBtn!.trigger('click')
 
+    // dialog 走 router.resolve 拼 URL，确认调到
     expect(resolveMock).toHaveBeenCalledWith('/admin/rules-review/preview/d-alpha')
-    expect(openSpy).toHaveBeenCalledTimes(1)
-    expect(openSpy).toHaveBeenCalledWith(
-      '/admin/rules-review/preview/d-alpha',
-      '_blank',
-      'noopener,noreferrer',
-    )
-
-    openSpy.mockRestore()
+    // 内部 ref 应已更新（vm 暴露 setup 返回值）
+    const vm = wrapper.vm as unknown as { previewVisible: boolean; previewUrl: string }
+    expect(vm.previewVisible).toBe(true)
+    expect(vm.previewUrl).toBe('/admin/rules-review/preview/d-alpha')
   })
 })


### PR DESCRIPTION
之前用 window.open 新窗打开预览路由，新 tab 的 sessionStorage 是空的，拿不到 token，被 beforeEach 守卫踢回 /user-info（你看到的新窗打开是登录页）。

改成 el-dialog 内嵌同源 iframe，共享当前会话，沉浸式预览，关掉就回审核面板。原预览路由保留作直链访问。