### PR TITLE
fix(admin): hide chrome and stretch canvas in preview iframe

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -1,6 +1,6 @@
 <template>
-  <div :class="['main-layout', { 'auth-only-layout': !isLoggedIn }]" data-testid="app-shell">
-    <header v-if="isLoggedIn" class="top-header">
+  <div :class="['main-layout', { 'auth-only-layout': !isLoggedIn, 'preview-shell': isPreviewIframe }]" data-testid="app-shell">
+    <header v-if="isLoggedIn && !isPreviewIframe" class="top-header">
       <div class="header-logo">WildCard</div>
       <div class="header-nav">
         <div class="top-nav-item" @click="handleTeamIntro">团队介绍</div>
@@ -9,7 +9,7 @@
       </div>
     </header>
     <div class="main-body">
-      <aside v-if="isLoggedIn" class="sidebar">
+      <aside v-if="isLoggedIn && !isPreviewIframe" class="sidebar">
         <nav class="nav">
           <router-link to="/" class="nav-item" exact-active-class="active">
             <el-icon><House /></el-icon>
@@ -59,13 +59,20 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { storeToRefs } from 'pinia'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { useUserStore } from '../stores/userStore'
 import { resolveAvatarUrl } from '../utils/avatar'
 
 const router = useRouter()
+const route = useRoute()
 const userStore = useUserStore()
 const { isLoggedIn, username, email, avatar } = storeToRefs(userStore)
+
+// 审核员预览路由（嵌在 dialog 同源 iframe 里）应该藏掉外层应用 chrome，
+// 让 RuleBuilder 占满 iframe 全部高度；否则顶栏 + 侧栏会挤压画布。
+const isPreviewIframe = computed(() =>
+  Boolean(route?.path?.startsWith('/admin/rules-review/preview/')),
+)
 
 const displayAvatar = computed(() => resolveAvatarUrl(avatar.value))
 const displayUsername = computed(() => username.value || '未登录')

--- a/src/views/RuleBuilderView.vue
+++ b/src/views/RuleBuilderView.vue
@@ -978,7 +978,10 @@ const openTutorial = () => {
   text-align: left;
 }
 
+/* 审核员只读模式下，本页嵌在 dialog 同源 iframe 里；iframe 视窗等于 dialog body，
+ * 没有外层 64px 应用头需要减。用 100% 占满 iframe 全部高度，避免画布被截到一截。 */
 .rule-builder-page.readonly-mode {
+  height: 100%;
   grid-template-rows: auto auto auto 1fr;
 }
 


### PR DESCRIPTION
iframe 里 MainLayout 还在画顶栏 + 侧栏，再加 RuleBuilder 的 calc(100vh - 64px) 把画布挤到屏幕外。

MainLayout 检测 /admin/rules-review/preview/ 路径时跳过 header + sidebar；RuleBuilderView readonly 模式 height: 100% 拿满 iframe。