### PR TITLE
fix(admin): pass height down to RuleBuilder inside preview iframe

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -106,6 +106,20 @@ const handleHelp = () => {
   overflow: hidden;
 }
 
+/* 审核员预览 iframe：藏掉外层 chrome，再把高度链强制贯通到 RuleBuilder。
+ * 父链 #app 用了 min-height:100svh 和 flex column，预览时改成显式 height
+ * 让里头的 height:100% 能拿到具体值。 */
+.preview-shell {
+  height: 100vh;
+}
+.preview-shell .main-body,
+.preview-shell .main-content,
+.preview-shell .content-area {
+  height: 100%;
+  min-height: 0;
+  flex: 1 1 auto;
+}
+
 .auth-only-layout {
   background: #fff;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -163,6 +163,18 @@ code {
   box-sizing: border-box;
 }
 
+/* 审核员预览路由：iframe 嵌入版本不需要居中、边框、最大宽度限制。
+ * 让 #app 撑满 iframe，确保里头的 height:100% 链路有正确的父级高度。
+ * 用 :has 直接探测 preview-shell 子元素，避免 JS 改 root class。 */
+#app:has(.preview-shell) {
+  width: 100%;
+  max-width: none;
+  border: 0;
+  margin: 0;
+  height: 100vh;
+  min-height: 100vh;
+}
+
 #center {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
上一波 fix 只藏了顶栏侧栏，但 #app (min-height:100svh + 1126px) 和 .content-area (flex:1 无显式 height) 让 height:100% 链路塌成 0，所以画布和 workspace tabs 全空。

加 :has(.preview-shell) override，preview-shell 子节点上层全显式 height:100%。