### PR TITLE
fix(admin): visual preview navigates current tab instead of dialog/iframe

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -1,6 +1,6 @@
 <template>
-  <div :class="['main-layout', { 'auth-only-layout': !isLoggedIn, 'preview-shell': isPreviewIframe }]" data-testid="app-shell">
-    <header v-if="isLoggedIn && !isPreviewIframe" class="top-header">
+  <div :class="['main-layout', { 'auth-only-layout': !isLoggedIn }]" data-testid="app-shell">
+    <header v-if="isLoggedIn" class="top-header">
       <div class="header-logo">WildCard</div>
       <div class="header-nav">
         <div class="top-nav-item" @click="handleTeamIntro">团队介绍</div>
@@ -9,7 +9,7 @@
       </div>
     </header>
     <div class="main-body">
-      <aside v-if="isLoggedIn && !isPreviewIframe" class="sidebar">
+      <aside v-if="isLoggedIn" class="sidebar">
         <nav class="nav">
           <router-link to="/" class="nav-item" exact-active-class="active">
             <el-icon><House /></el-icon>
@@ -59,20 +59,13 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { storeToRefs } from 'pinia'
-import { useRoute, useRouter } from 'vue-router'
+import { useRouter } from 'vue-router'
 import { useUserStore } from '../stores/userStore'
 import { resolveAvatarUrl } from '../utils/avatar'
 
 const router = useRouter()
-const route = useRoute()
 const userStore = useUserStore()
 const { isLoggedIn, username, email, avatar } = storeToRefs(userStore)
-
-// 审核员预览路由（嵌在 dialog 同源 iframe 里）应该藏掉外层应用 chrome，
-// 让 RuleBuilder 占满 iframe 全部高度；否则顶栏 + 侧栏会挤压画布。
-const isPreviewIframe = computed(() =>
-  Boolean(route?.path?.startsWith('/admin/rules-review/preview/')),
-)
 
 const displayAvatar = computed(() => resolveAvatarUrl(avatar.value))
 const displayUsername = computed(() => username.value || '未登录')
@@ -109,17 +102,6 @@ const handleHelp = () => {
 /* 审核员预览 iframe：藏掉外层 chrome，再把高度链强制贯通到 RuleBuilder。
  * 父链 #app 用了 min-height:100svh 和 flex column，预览时改成显式 height
  * 让里头的 height:100% 能拿到具体值。 */
-.preview-shell {
-  height: 100vh;
-}
-.preview-shell .main-body,
-.preview-shell .main-content,
-.preview-shell .content-area {
-  height: 100%;
-  min-height: 0;
-  flex: 1 1 auto;
-}
-
 .auth-only-layout {
   background: #fff;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -163,18 +163,6 @@ code {
   box-sizing: border-box;
 }
 
-/* 审核员预览路由：iframe 嵌入版本不需要居中、边框、最大宽度限制。
- * 让 #app 撑满 iframe，确保里头的 height:100% 链路有正确的父级高度。
- * 用 :has 直接探测 preview-shell 子元素，避免 JS 改 root class。 */
-#app:has(.preview-shell) {
-  width: 100%;
-  max-width: none;
-  border: 0;
-  margin: 0;
-  height: 100vh;
-  min-height: 100vh;
-}
-
 #center {
   display: flex;
   flex-direction: column;

--- a/src/views/AdminRuleReviewView.vue
+++ b/src/views/AdminRuleReviewView.vue
@@ -101,25 +101,6 @@
         </template>
       </section>
     </div>
-
-    <el-dialog
-      v-model="previewVisible"
-      title="可视化预览"
-      fullscreen
-      class="preview-dialog"
-      :close-on-click-modal="false"
-      :close-on-press-escape="true"
-      append-to-body
-      destroy-on-close
-      @close="closePreview"
-    >
-      <iframe
-        v-if="previewUrl"
-        :src="previewUrl"
-        class="preview-iframe"
-        title="规则可视化预览"
-      ></iframe>
-    </el-dialog>
   </div>
 </template>
 
@@ -137,8 +118,6 @@ const rejecting = ref(false)
 const drafts = ref<PendingReviewDraft[]>([])
 const selectedId = ref<string>('')
 const designVisible = ref(false)
-const previewVisible = ref(false)
-const previewUrl = ref('')
 
 const selectedDraft = computed(() =>
   drafts.value.find(draft => draft.draftId === selectedId.value) || null,
@@ -184,19 +163,14 @@ function selectDraft(draftId: string) {
 }
 
 /**
- * 在新标签页打开 RuleBuilderView 的只读预览。
- * 用 router.resolve 而非直接拼字符串，方便测试用 mock router.resolve 验证调用，并保留 history mode 的 base。
- * window.open 用 noopener,noreferrer 切断 opener，新窗不能 navigate 回这里。
+ * 当前 tab 跳转到 RuleBuilder 的只读预览路由。
+ * 之前尝试过 window.open 新窗（sessionStorage 不跨 tab）和 dialog + 同源 iframe
+ * （内嵌时高度链塌成 0），都不顺；改回最朴素的 router.push，
+ * 看完点页面里的「返回审核面板」按钮回来。
  */
 function openVisualPreview() {
   if (!selectedDraft.value) return
-  previewUrl.value = router.resolve(`/admin/rules-review/preview/${selectedDraft.value.draftId}`).href
-  previewVisible.value = true
-}
-
-function closePreview() {
-  previewVisible.value = false
-  previewUrl.value = ''
+  void router.push(`/admin/rules-review/preview/${selectedDraft.value.draftId}`)
 }
 
 async function loadPending() {
@@ -529,27 +503,5 @@ onMounted(() => {
   .pending-list {
     max-height: none;
   }
-}
-
-/* 用 fullscreen prop 后 dialog 自身 height:100% 且去除 max-height；
- * 仍需让 body 拿满去掉 padding，iframe 才能贴边占满。 */
-.preview-dialog :deep(.el-dialog) {
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-}
-
-.preview-dialog :deep(.el-dialog__body) {
-  flex: 1 1 auto;
-  padding: 0;
-  min-height: 0;
-  overflow: hidden;
-}
-
-.preview-iframe {
-  width: 100%;
-  height: 100%;
-  border: 0;
-  display: block;
 }
 </style>

--- a/src/views/RuleBuilderView.vue
+++ b/src/views/RuleBuilderView.vue
@@ -978,10 +978,7 @@ const openTutorial = () => {
   text-align: left;
 }
 
-/* 审核员只读模式下，本页嵌在 dialog 同源 iframe 里；iframe 视窗等于 dialog body，
- * 没有外层 64px 应用头需要减。用 100% 占满 iframe 全部高度，避免画布被截到一截。 */
 .rule-builder-page.readonly-mode {
-  height: 100%;
   grid-template-rows: auto auto auto 1fr;
 }
 

--- a/src/views/__tests__/AdminRuleReviewView.spec.ts
+++ b/src/views/__tests__/AdminRuleReviewView.spec.ts
@@ -17,6 +17,7 @@ vi.mock('../../api/config', () => ({
 }))
 
 const resolveMock = vi.fn((path: string) => ({ href: path }))
+const pushMock = vi.fn()
 
 vi.mock('vue-router', async () => {
   const actual = await vi.importActual<typeof import('vue-router')>('vue-router')
@@ -24,7 +25,7 @@ vi.mock('vue-router', async () => {
     ...actual,
     useRouter: () => ({
       resolve: resolveMock,
-      push: vi.fn(),
+      push: pushMock,
       replace: vi.fn(),
     }),
   }
@@ -218,8 +219,8 @@ describe('AdminRuleReviewView', () => {
     expect(ElMessage.error).toHaveBeenCalledWith('权限不足')
   })
 
-  it('点击"可视化预览"按钮弹出同源 iframe dialog', async () => {
-    resolveMock.mockClear()
+  it('点击"可视化预览"按钮跳转到只读预览路由', async () => {
+    pushMock.mockClear()
 
     const wrapper = mountView()
     await flushPromises()
@@ -233,11 +234,6 @@ describe('AdminRuleReviewView', () => {
     expect(previewBtn).toBeTruthy()
     await previewBtn!.trigger('click')
 
-    // dialog 走 router.resolve 拼 URL，确认调到
-    expect(resolveMock).toHaveBeenCalledWith('/admin/rules-review/preview/d-alpha')
-    // 内部 ref 应已更新（vm 暴露 setup 返回值）
-    const vm = wrapper.vm as unknown as { previewVisible: boolean; previewUrl: string }
-    expect(vm.previewVisible).toBe(true)
-    expect(vm.previewUrl).toBe('/admin/rules-review/preview/d-alpha')
+    expect(pushMock).toHaveBeenCalledWith('/admin/rules-review/preview/d-alpha')
   })
 })


### PR DESCRIPTION
新窗 + iframe 两条路都倒在高度链 / 跨 tab session 上。改回最朴素的 router.push 当前 tab 跳转，readonly RuleBuilder 自带的'返回审核面板'按钮够用了。

回滚 MainLayout 的 preview-shell 分支、style.css 的 :has hack、RuleBuilder readonly height:100%，删 AdminRuleReviewView 的 el-dialog + iframe。