### PR TITLE
test: cover latest rule market frontend flows

### DIFF
--- a/src/api/__tests__/market.spec.ts
+++ b/src/api/__tests__/market.spec.ts
@@ -1,15 +1,32 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { apiGet, apiPost } from '../request'
 import { marketApi, resolveDeveloperAvatar } from '../market'
+import { AUTH_TOKEN_STORAGE_KEY } from '../../utils/storageNamespace'
 
 vi.mock('../request', () => ({
   apiGet: vi.fn(),
   apiPost: vi.fn(),
 }))
 
+vi.mock('../config', () => ({
+  getApiUrl: (endpoint: string) => `http://test${endpoint}`,
+  shouldUseMarketMockApi: () => false,
+}))
+
 describe('marketApi', () => {
+  const fetchMock = vi.fn()
+  const originalFetch = globalThis.fetch
+
   beforeEach(() => {
     vi.clearAllMocks()
+    fetchMock.mockReset()
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+    window.sessionStorage.clear()
+    window.localStorage.clear()
+  })
+
+  afterAll(() => {
+    globalThis.fetch = originalFetch
   })
 
   it('lists published rules through the real backend endpoint with encoded filters', async () => {
@@ -60,6 +77,40 @@ describe('marketApi', () => {
       { name: 'My Fork' },
       expect.objectContaining({ useMock: false }),
     )
+  })
+
+  it('uploads review images as multipart with the current auth token', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      text: async () => JSON.stringify({ success: true, data: { imageUrl: '/static/review-images/r1.png' } }),
+    })
+    window.sessionStorage.setItem(AUTH_TOKEN_STORAGE_KEY, 'token-123')
+    const file = new File(['image-bytes'], 'review.png', { type: 'image/png' })
+
+    const result = await marketApi.uploadReviewImage(file)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('http://test/api/rules/reviews/images')
+    expect(init.method).toBe('POST')
+    expect(init.credentials).toBe('include')
+    expect(init.headers).toEqual({ Authorization: 'Bearer token-123' })
+    expect(init.body).toBeInstanceOf(FormData)
+    expect(result).toEqual({ success: true, data: { imageUrl: '/static/review-images/r1.png' } })
+  })
+
+  it('returns backend upload errors without synthesizing an image URL', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      text: async () => JSON.stringify({ message: '仅支持 png / jpeg / webp 格式' }),
+    })
+    const file = new File(['bad'], 'review.gif', { type: 'image/gif' })
+
+    const result = await marketApi.uploadReviewImage(file)
+
+    expect(result.success).toBe(false)
+    expect(result.message).toBe('仅支持 png / jpeg / webp 格式')
   })
 })
 

--- a/src/views/__tests__/PublishFormView.spec.ts
+++ b/src/views/__tests__/PublishFormView.spec.ts
@@ -193,4 +193,42 @@ describe('PublishFormView', () => {
       '/static/rule-images/new.png',
     ])
   })
+
+  it('封面上传拒绝非 png/jpeg/webp 文件且不调用上传接口', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    const componentInstance = wrapper.vm as unknown as {
+      handleCoverChange: (file: { raw: File }) => Promise<void>
+    }
+    const fakeFile = new File(['text'], 'cover.txt', { type: 'text/plain' })
+    await componentInstance.handleCoverChange({ raw: fakeFile })
+    await flushPromises()
+
+    expect(ruleApi.uploadRuleImage).not.toHaveBeenCalled()
+    expect(ElMessage.warning).toHaveBeenCalledWith('仅支持 PNG / JPEG / WEBP 格式的图片')
+  })
+
+  it('截图上传达到 10 张上限时提示并跳过上传', async () => {
+    vi.mocked(ruleApi.getDraft).mockResolvedValueOnce({
+      success: true,
+      data: cloneDraft({
+        screenshotUrls: Array.from({ length: 10 }, (_, index) => `/static/rule-images/${index}.png`),
+      }),
+    })
+    const wrapper = mountView()
+    await flushPromises()
+
+    const componentInstance = wrapper.vm as unknown as {
+      handleScreenshotChange: (file: { raw: File }) => Promise<void>
+      screenshotUrls: string[]
+    }
+    const fakeFile = new File(['x'], 'shot.png', { type: 'image/png' })
+    await componentInstance.handleScreenshotChange({ raw: fakeFile })
+    await flushPromises()
+
+    expect(componentInstance.screenshotUrls).toHaveLength(10)
+    expect(ruleApi.uploadRuleImage).not.toHaveBeenCalled()
+    expect(ElMessage.warning).toHaveBeenCalledWith('最多 10 张截图')
+  })
 })

--- a/src/views/__tests__/RuleBuilderView.spec.ts
+++ b/src/views/__tests__/RuleBuilderView.spec.ts
@@ -428,5 +428,39 @@ describe('RuleBuilderView.vue', () => {
       expect(banner.text()).toContain('只读预览模式')
       expect(banner.text()).toContain('审核员')
     })
+
+    it('readonly 模式进入流程画布时把 readonly prop 传给 RuleFlowCanvas', async () => {
+      enterPreviewRoute()
+      adminGetDraftMock.mockResolvedValueOnce({
+        success: true,
+        data: {
+          id: 'd-preview',
+          name: 'Preview 规则',
+          playerCount: 3,
+          description: '',
+          status: 'pendingReview',
+          updatedAt: 0,
+          createdAt: 0,
+          design: emptyDesignPayload,
+        },
+      })
+      const wrapper = mount(RuleBuilderView, {
+        global: {
+          stubs: {
+            ...previewStubs,
+            'rule-flow-canvas': {
+              props: ['readonly'],
+              template: '<div class="flow-canvas" :data-readonly="String(readonly)"></div>',
+            },
+          },
+        },
+      })
+      await flushPromises()
+
+      await wrapper.find('.workspace-tab:nth-child(5)').trigger('click')
+      await flushPromises()
+
+      expect(wrapper.find('.flow-canvas').attributes('data-readonly')).toBe('true')
+    })
   })
 })

--- a/src/views/__tests__/RuleMarketDetailView.spec.ts
+++ b/src/views/__tests__/RuleMarketDetailView.spec.ts
@@ -20,6 +20,7 @@ vi.mock('../../api/market', async () => {
       ...actual.marketApi,
       getPublishedRuleDetail: vi.fn(),
       postRuleReview: vi.fn(),
+      uploadReviewImage: vi.fn(),
     },
   }
 })
@@ -104,6 +105,10 @@ describe('RuleMarketDetailView', () => {
         createdAt: new Date('2026-05-30T00:00:00Z').getTime(),
       },
     })
+    vi.mocked(marketApi.uploadReviewImage).mockResolvedValue({
+      success: true,
+      data: { imageUrl: '/static/review-images/review-2.png' },
+    })
   })
 
   it('loads and renders rule detail, developer, intro, and existing reviews', async () => {
@@ -115,6 +120,27 @@ describe('RuleMarketDetailView', () => {
     expect(wrapper.text()).toContain('每名玩家翻出一张牌')
     expect(wrapper.text()).toContain('WildCard 内置')
     expect(wrapper.text()).toContain('节奏很快')
+  })
+
+  it('resolves cover and screenshot short URLs against the backend host', async () => {
+    vi.mocked(marketApi.getPublishedRuleDetail).mockResolvedValueOnce({
+      success: true,
+      data: {
+        ...structuredClone(rule),
+        coverUrl: '/static/rule-images/cover.png',
+        screenshots: ['/static/rule-images/shot.png'],
+      },
+    })
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.find('.screenshot-panel img').attributes('src')).toBe(
+      'http://localhost:3000/static/rule-images/cover.png',
+    )
+    expect(wrapper.find('.screenshot-single').attributes('src')).toBe(
+      'http://localhost:3000/static/rule-images/shot.png',
+    )
   })
 
   it('navigates to developer, room search, and quick create destinations', async () => {
@@ -159,6 +185,68 @@ describe('RuleMarketDetailView', () => {
     expect(wrapper.text()).toContain('我')
     expect(wrapper.text()).toContain('值得推荐')
     expect(ElMessage.success).toHaveBeenCalledWith('评论已提交')
+  })
+
+  it('uploads a selected review image before submitting the review with the returned short URL', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    const file = new File(['image'], 'review.png', { type: 'image/png' })
+    const component = wrapper.vm as unknown as {
+      handleImageChange: (file: { raw: File }) => void
+    }
+    component.handleImageChange({ raw: file })
+    await flushPromises()
+
+    await wrapper.find('textarea').setValue('  带图评论  ')
+    await wrapper.findAll('button').find(button => button.text() === '提交评论')?.trigger('click')
+    await flushPromises()
+
+    expect(marketApi.uploadReviewImage).toHaveBeenCalledWith(file)
+    expect(marketApi.postRuleReview).toHaveBeenCalledWith('builtin-war-rule', {
+      rating: 5,
+      content: '带图评论',
+      imageUrl: '/static/review-images/review-2.png',
+    })
+  })
+
+  it('stops review submission when the selected image upload fails', async () => {
+    vi.mocked(marketApi.uploadReviewImage).mockResolvedValueOnce({
+      success: false,
+      message: '评论图片不能超过 2MB',
+    })
+    const wrapper = mountView()
+    await flushPromises()
+
+    const file = new File(['image'], 'review.png', { type: 'image/png' })
+    const component = wrapper.vm as unknown as {
+      handleImageChange: (file: { raw: File }) => void
+    }
+    component.handleImageChange({ raw: file })
+    await flushPromises()
+
+    await wrapper.find('textarea').setValue('带图评论')
+    await wrapper.findAll('button').find(button => button.text() === '提交评论')?.trigger('click')
+    await flushPromises()
+
+    expect(marketApi.uploadReviewImage).toHaveBeenCalledWith(file)
+    expect(marketApi.postRuleReview).not.toHaveBeenCalled()
+    expect(ElMessage.error).toHaveBeenCalledWith('评论图片不能超过 2MB')
+  })
+
+  it('rejects non-image files before review image preview/upload state is set', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    const file = new File(['not-image'], 'notes.txt', { type: 'text/plain' })
+    const component = wrapper.vm as unknown as {
+      handleImageChange: (file: { raw: File }) => void
+    }
+    component.handleImageChange({ raw: file })
+    await flushPromises()
+
+    expect(wrapper.text()).not.toContain('notes.txt')
+    expect(ElMessage.warning).toHaveBeenCalledWith('请上传图片文件')
   })
 
   it('shows a load error when rule detail is unavailable', async () => {


### PR DESCRIPTION
## Summary\n- cover review image upload API behavior, including auth token propagation and backend upload errors\n- cover rule detail image URL resolution and image-backed review submission flow\n- cover publish form image validation / screenshot limit behavior\n- cover readonly preview passing readonly mode into the flow canvas\n\n## Tests\n- npm run test:unit -- src/api/__tests__/market.spec.ts src/views/__tests__/RuleMarketDetailView.spec.ts src/views/__tests__/PublishFormView.spec.ts src/views/__tests__/RuleBuilderView.spec.ts\n- npm run test:unit\n\nCloses #174