### PR TITLE
feat:举报与审核系统前端页面展示

### DIFF
--- a/src/api/report.ts
+++ b/src/api/report.ts
@@ -1,0 +1,220 @@
+import { apiGet, apiPost } from './request'
+import { scopedStorageKey } from '../utils/storageNamespace'
+
+export type ReportTargetType = 'user' | 'rule' | 'review' | 'player_behavior'
+export type ReportStatus = 'pending' | 'resolved' | 'rejected'
+export type ReportAction = 'ban_user' | 'ban_rule' | 'dismiss'
+
+export interface ReportContext {
+  targetLabel?: string
+  roomCode?: string
+  sessionId?: string
+  ruleId?: string
+  sourcePath?: string
+  snapshot?: Record<string, unknown>
+}
+
+export interface Report {
+  id: string
+  reporterId: string
+  reporterName: string
+  reporterAvatar?: string
+  targetType: ReportTargetType
+  targetId: string
+  reason: string
+  details: string
+  status: ReportStatus
+  createdAt: number
+  updatedAt: number
+  context?: ReportContext
+  actionLog?: ReportActionLog[]
+}
+
+export interface ReportActionLog {
+  id: string
+  action: ReportAction
+  operatorId: string
+  note: string
+  createdAt: number
+}
+
+export interface SubmitReportPayload {
+  reporterId: string
+  reporterName: string
+  reporterAvatar?: string
+  targetType: ReportTargetType
+  targetId: string
+  reason: string
+  details: string
+  context?: ReportContext
+}
+
+export interface ReportQuery {
+  status?: ReportStatus | 'all'
+  targetType?: ReportTargetType | 'all'
+  keyword?: string
+  page?: number
+}
+
+export interface ReportActionPayload {
+  action: ReportAction
+  note?: string
+  params?: Record<string, unknown>
+}
+
+interface ApiResult<T = unknown> {
+  success: boolean
+  data?: T
+  message?: string
+}
+
+const REPORT_STORAGE_KEY = scopedStorageKey('mock-reports')
+
+function hasStorage() {
+  return typeof window !== 'undefined' && Boolean(window.localStorage)
+}
+
+function readLocalReports(): Report[] {
+  if (!hasStorage()) return []
+  const raw = window.localStorage.getItem(REPORT_STORAGE_KEY)
+  if (!raw) return []
+  try {
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
+function writeLocalReports(reports: Report[]) {
+  if (!hasStorage()) return
+  window.localStorage.setItem(REPORT_STORAGE_KEY, JSON.stringify(reports))
+}
+
+function createLocalReport(payload: SubmitReportPayload): Report {
+  const now = Date.now()
+  return {
+    id: `report-${now}-${Math.random().toString(36).slice(2, 8)}`,
+    reporterId: payload.reporterId,
+    reporterName: payload.reporterName,
+    reporterAvatar: payload.reporterAvatar,
+    targetType: payload.targetType,
+    targetId: payload.targetId,
+    reason: payload.reason,
+    details: payload.details,
+    status: 'pending',
+    createdAt: now,
+    updatedAt: now,
+    context: payload.context,
+  }
+}
+
+function queryString(params: ReportQuery = {}) {
+  const searchParams = new URLSearchParams()
+  if (params.status && params.status !== 'all') searchParams.set('status', params.status)
+  if (params.targetType && params.targetType !== 'all') searchParams.set('targetType', params.targetType)
+  if (params.keyword) searchParams.set('keyword', params.keyword)
+  if (params.page) searchParams.set('page', String(params.page))
+  const value = searchParams.toString()
+  return value ? `?${value}` : ''
+}
+
+function filterLocalReports(params: ReportQuery = {}) {
+  const keyword = params.keyword?.trim().toLowerCase()
+  return readLocalReports()
+    .filter((report) => params.status === 'all' || !params.status || report.status === params.status)
+    .filter((report) => params.targetType === 'all' || !params.targetType || report.targetType === params.targetType)
+    .filter((report) => {
+      if (!keyword) return true
+      return [
+        report.targetId,
+        report.reason,
+        report.details,
+        report.context?.targetLabel,
+        report.reporterName,
+      ].some((item) => String(item || '').toLowerCase().includes(keyword))
+    })
+    .sort((left, right) => right.createdAt - left.createdAt)
+}
+
+function saveLocalAction(reportId: string, payload: ReportActionPayload): ApiResult<Report> {
+  const reports = readLocalReports()
+  const report = reports.find((item) => item.id === reportId)
+  if (!report) {
+    return { success: false, message: '举报记录不存在' }
+  }
+
+  const now = Date.now()
+  report.status = payload.action === 'dismiss' ? 'rejected' : 'resolved'
+  report.updatedAt = now
+  report.actionLog = [
+    ...(report.actionLog || []),
+    {
+      id: `action-${now}`,
+      action: payload.action,
+      operatorId: 'admin',
+      note: payload.note || '',
+      createdAt: now,
+    },
+  ]
+  writeLocalReports(reports)
+  return { success: true, data: report }
+}
+
+export const reportApi = {
+  async submit(payload: SubmitReportPayload): Promise<ApiResult<Report>> {
+    const result = await apiPost<ApiResult<Report>>('/api/reports', payload, { useMock: false })
+    if (result.success) {
+      return result
+    }
+
+    const report = createLocalReport(payload)
+    const reports = readLocalReports()
+    writeLocalReports([report, ...reports])
+    return { success: true, data: report, message: '已保存到本地模拟举报列表' }
+  },
+
+  async list(params: ReportQuery = {}): Promise<ApiResult<Report[]>> {
+    const result = await apiGet<ApiResult<Report[]>>(`/api/reports${queryString(params)}`, { useMock: false })
+    if (result.success && Array.isArray(result.data)) {
+      return result
+    }
+
+    return { success: true, data: filterLocalReports(params) }
+  },
+
+  async get(id: string): Promise<ApiResult<Report>> {
+    const result = await apiGet<ApiResult<Report>>(`/api/reports/${encodeURIComponent(id)}`, { useMock: false })
+    if (result.success && result.data) {
+      return result
+    }
+
+    const report = readLocalReports().find((item) => item.id === id)
+    return report ? { success: true, data: report } : { success: false, message: '举报记录不存在' }
+  },
+
+  async counts(): Promise<ApiResult<{ pending: number }>> {
+    const result = await apiGet<ApiResult<{ pending: number }>>('/api/reports/counts', { useMock: false })
+    if (result.success && result.data) {
+      return result
+    }
+
+    return {
+      success: true,
+      data: { pending: readLocalReports().filter((report) => report.status === 'pending').length },
+    }
+  },
+
+  async action(reportId: string, payload: ReportActionPayload): Promise<ApiResult<Report>> {
+    const result = await apiPost<ApiResult<Report>>(
+      `/api/reports/${encodeURIComponent(reportId)}/action`,
+      payload,
+      { useMock: false },
+    )
+    if (result.success) {
+      return result
+    }
+
+    return saveLocalAction(reportId, payload)
+  },
+}

--- a/src/components/report/AdminReportDetail.vue
+++ b/src/components/report/AdminReportDetail.vue
@@ -1,0 +1,231 @@
+<template>
+  <section class="report-detail">
+    <el-empty v-if="!report" description="请选择一条举报" />
+    <template v-else>
+      <header class="detail-header">
+        <div>
+          <h2>{{ report.context?.targetLabel || report.targetId }}</h2>
+          <p>{{ typeText[report.targetType] || report.targetType }} · {{ statusText }}</p>
+        </div>
+        <el-tag :type="report.status === 'pending' ? 'danger' : report.status === 'resolved' ? 'success' : 'info'">
+          {{ statusText }}
+        </el-tag>
+      </header>
+
+      <dl class="detail-grid">
+        <div>
+          <dt>举报人</dt>
+          <dd class="reporter-cell">
+            <img v-if="report.reporterAvatar" :src="report.reporterAvatar" :alt="report.reporterName">
+            <span>{{ report.reporterName || report.reporterId }}</span>
+          </dd>
+        </div>
+        <div>
+          <dt>目标 ID</dt>
+          <dd>{{ report.targetId }}</dd>
+        </div>
+        <div>
+          <dt>提交时间</dt>
+          <dd>{{ formatTime(report.createdAt) }}</dd>
+        </div>
+        <div>
+          <dt>来源页面</dt>
+          <dd>{{ report.context?.sourcePath || '-' }}</dd>
+        </div>
+      </dl>
+
+      <section class="detail-section">
+        <h3>举报理由</h3>
+        <p>{{ report.reason }}</p>
+      </section>
+
+      <section class="detail-section">
+        <h3>补充说明</h3>
+        <p>{{ report.details || '无补充说明' }}</p>
+      </section>
+
+      <section v-if="report.actionLog?.length" class="detail-section">
+        <h3>处理记录</h3>
+        <ul class="action-log">
+          <li v-for="log in report.actionLog" :key="log.id">
+            <strong>{{ actionText[log.action] || log.action }}</strong>
+            <span>{{ formatTime(log.createdAt) }}</span>
+            <p>{{ log.note || '无备注' }}</p>
+          </li>
+        </ul>
+      </section>
+
+      <footer class="detail-actions">
+        <el-button
+          type="danger"
+          :disabled="report.status !== 'pending' || !canBanUser"
+          @click="$emit('action', 'ban_user')"
+        >
+          封禁用户
+        </el-button>
+        <el-button
+          type="warning"
+          :disabled="report.status !== 'pending' || !canBanRule"
+          @click="$emit('action', 'ban_rule')"
+        >
+          封禁规则
+        </el-button>
+        <el-button
+          :disabled="report.status !== 'pending'"
+          @click="$emit('action', 'dismiss')"
+        >
+          驳回
+        </el-button>
+      </footer>
+    </template>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { Report, ReportAction } from '../../api/report'
+
+const props = defineProps<{
+  report: Report | null
+}>()
+
+defineEmits<{
+  action: [action: ReportAction]
+}>()
+
+const typeText: Record<string, string> = {
+  user: '用户举报',
+  rule: '规则举报',
+  review: '评价举报',
+  player_behavior: '对局行为举报',
+}
+
+const actionText: Record<string, string> = {
+  ban_user: '封禁用户',
+  ban_rule: '封禁规则',
+  dismiss: '驳回',
+}
+
+const statusText = computed(() => {
+  if (!props.report) return ''
+  return props.report.status === 'pending' ? '待处理' : props.report.status === 'resolved' ? '已处理' : '已驳回'
+})
+
+const canBanUser = computed(() => props.report?.targetType === 'user' || props.report?.targetType === 'player_behavior')
+const canBanRule = computed(() => props.report?.targetType === 'rule' || props.report?.targetType === 'review')
+
+function formatTime(timestamp: number) {
+  return new Date(timestamp).toLocaleString('zh-CN')
+}
+</script>
+
+<style scoped>
+.report-detail {
+  min-height: 420px;
+  padding: 22px 24px;
+  border: 1px solid #dfe3ec;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.detail-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.detail-header h2 {
+  margin: 0;
+  font-size: 22px;
+  letter-spacing: 0;
+  overflow-wrap: anywhere;
+}
+
+.detail-header p {
+  margin: 6px 0 0;
+  color: #6b7280;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin: 18px 0 0;
+}
+
+.detail-grid div {
+  padding: 10px 12px;
+  border-radius: 6px;
+  background: #f5f6fa;
+}
+
+.detail-grid dt {
+  color: #6b7280;
+  font-size: 12px;
+}
+
+.detail-grid dd {
+  margin: 4px 0 0;
+  overflow-wrap: anywhere;
+}
+
+.reporter-cell {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.reporter-cell img {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.detail-section {
+  margin-top: 18px;
+  padding-top: 16px;
+  border-top: 1px solid #eef0f6;
+}
+
+.detail-section h3 {
+  margin: 0 0 8px;
+  font-size: 15px;
+}
+
+.detail-section p {
+  margin: 0;
+  color: #3a4050;
+  line-height: 1.65;
+  white-space: pre-wrap;
+}
+
+.action-log {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.action-log li + li {
+  margin-top: 10px;
+}
+
+.action-log span {
+  margin-left: 8px;
+  color: #6b7280;
+  font-size: 12px;
+}
+
+.detail-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 24px;
+}
+
+@media (max-width: 760px) {
+  .detail-grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/src/components/report/ReportButton.vue
+++ b/src/components/report/ReportButton.vue
@@ -1,0 +1,89 @@
+<template>
+  <span class="report-button-wrap" @click.stop>
+    <el-tooltip :content="tooltip" placement="top">
+      <el-button
+        :size="small ? 'small' : 'default'"
+        :type="text ? 'danger' : undefined"
+        :text="text"
+        :circle="!text"
+        class="report-button"
+        :aria-label="tooltip"
+        @click="open"
+      >
+        <el-icon><Warning /></el-icon>
+        <span v-if="text" class="report-text">{{ tooltip }}</span>
+      </el-button>
+    </el-tooltip>
+
+    <ReportModal
+      v-model="visible"
+      :target-type="targetType"
+      :target-id="targetId"
+      :target-label="targetLabel"
+      :context="context"
+      @submitted="emit('submitted')"
+    />
+  </span>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { ElMessage } from 'element-plus'
+import { Warning } from '@element-plus/icons-vue'
+import ReportModal from './ReportModal.vue'
+import type { ReportContext, ReportTargetType } from '../../api/report'
+import { useUserStore } from '../../stores/userStore'
+
+defineProps<{
+  targetType: ReportTargetType
+  targetId: string
+  targetLabel?: string
+  context?: ReportContext
+  tooltip?: string
+  small?: boolean
+  text?: boolean
+}>()
+
+const emit = defineEmits<{
+  opened: []
+  submitted: []
+}>()
+
+const router = useRouter()
+const userStore = useUserStore()
+const visible = ref(false)
+
+function open() {
+  if (!userStore.isLoggedIn) {
+    ElMessage.warning('请先登录后再提交举报')
+    void router.push('/user-info')
+    return
+  }
+  visible.value = true
+  emit('opened')
+}
+</script>
+
+<style scoped>
+.report-button-wrap {
+  display: inline-flex;
+  align-items: center;
+}
+
+.report-button {
+  border-color: #e3b1b1;
+  color: #9f2f2f;
+}
+
+.report-button:hover,
+.report-button:focus {
+  background: #fff0f0;
+  border-color: #d46b6b;
+  color: #8a1f1f;
+}
+
+.report-text {
+  margin-left: 4px;
+}
+</style>

--- a/src/components/report/ReportListItem.vue
+++ b/src/components/report/ReportListItem.vue
@@ -1,0 +1,109 @@
+<template>
+  <article
+    :class="['report-list-item', { active }]"
+    role="button"
+    tabindex="0"
+    @click="$emit('select')"
+    @keydown.enter.prevent="$emit('select')"
+  >
+    <div class="item-main">
+      <div class="item-title">
+        <el-tag size="small" :type="tagType">{{ targetTypeText }}</el-tag>
+        <strong>{{ report.context?.targetLabel || report.targetId }}</strong>
+      </div>
+      <p>{{ report.reason }}</p>
+      <span class="item-evidence">{{ evidenceText }}</span>
+    </div>
+    <div class="item-side">
+      <el-tag size="small" :type="statusTagType">{{ statusText }}</el-tag>
+      <span>{{ formatTime(report.createdAt) }}</span>
+    </div>
+  </article>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { Report } from '../../api/report'
+
+const props = defineProps<{
+  report: Report
+  active?: boolean
+}>()
+
+defineEmits<{
+  select: []
+}>()
+
+const typeText: Record<string, string> = {
+  user: '用户',
+  rule: '规则',
+  review: '评价',
+  player_behavior: '对局行为',
+}
+
+const targetTypeText = computed(() => typeText[props.report.targetType] || props.report.targetType)
+const tagType = computed(() => props.report.targetType === 'player_behavior' ? 'warning' : 'info')
+const statusText = computed(() => props.report.status === 'pending' ? '待处理' : props.report.status === 'resolved' ? '已处理' : '已驳回')
+const statusTagType = computed(() => props.report.status === 'pending' ? 'danger' : props.report.status === 'resolved' ? 'success' : 'info')
+const evidenceText = computed(() => {
+  return props.report.details || '无补充说明'
+})
+
+function formatTime(timestamp: number) {
+  return new Date(timestamp).toLocaleString('zh-CN', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+</script>
+
+<style scoped>
+.report-list-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 14px;
+  padding: 14px 16px;
+  border: 1px solid #dfe3ec;
+  border-radius: 8px;
+  background: #fff;
+  cursor: pointer;
+}
+
+.report-list-item:hover,
+.report-list-item.active {
+  border-color: #6f7cff;
+  box-shadow: 0 6px 18px rgba(42, 55, 120, 0.08);
+}
+
+.item-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.item-title strong {
+  overflow-wrap: anywhere;
+}
+
+.item-main p {
+  margin: 8px 0 4px;
+  color: #2d3142;
+}
+
+.item-evidence,
+.item-side {
+  color: #6b7280;
+  font-size: 12px;
+}
+
+.item-side {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+  white-space: nowrap;
+}
+</style>

--- a/src/components/report/ReportModal.vue
+++ b/src/components/report/ReportModal.vue
@@ -1,0 +1,130 @@
+<template>
+  <el-dialog
+    :model-value="modelValue"
+    title="提交举报"
+    width="520px"
+    class="report-dialog"
+    @update:model-value="emit('update:modelValue', $event)"
+    @closed="resetForm"
+  >
+    <el-form label-position="top" class="report-form">
+      <el-form-item label="举报对象">
+        <el-input :model-value="targetLabelText" disabled />
+      </el-form-item>
+
+      <el-form-item label="举报理由" required>
+        <el-input
+          v-model="reason"
+          type="textarea"
+          :rows="3"
+          maxlength="200"
+          show-word-limit
+          placeholder="请填写举报理由"
+        />
+      </el-form-item>
+
+      <el-form-item label="补充说明">
+        <el-input
+          v-model="details"
+          type="textarea"
+          :rows="4"
+          maxlength="500"
+          show-word-limit
+          placeholder="请描述具体情况、时间点或你观察到的证据"
+        />
+      </el-form-item>
+
+      <el-form-item label="举报人">
+        <el-input :model-value="reporterText" disabled />
+      </el-form-item>
+    </el-form>
+
+    <template #footer>
+      <el-button @click="close">取消</el-button>
+      <el-button type="primary" :loading="submitting" @click="submit">提交举报</el-button>
+    </template>
+  </el-dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useRoute } from 'vue-router'
+import { ElMessage } from 'element-plus'
+import { reportApi, type ReportContext, type ReportTargetType } from '../../api/report'
+import { useUserStore } from '../../stores/userStore'
+
+const props = defineProps<{
+  modelValue: boolean
+  targetType: ReportTargetType
+  targetId: string
+  targetLabel?: string
+  context?: ReportContext
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: boolean]
+  submitted: []
+}>()
+
+const route = useRoute()
+const userStore = useUserStore()
+const reason = ref('')
+const details = ref('')
+const submitting = ref(false)
+
+const targetLabelText = computed(() => props.targetLabel || `${props.targetType}:${props.targetId}`)
+const reporterText = computed(() => userStore.username || userStore.email || userStore.id || '当前用户')
+
+function close() {
+  emit('update:modelValue', false)
+}
+
+function resetForm() {
+  reason.value = ''
+  details.value = ''
+}
+
+async function submit() {
+  const trimmedReason = reason.value.trim()
+  if (!trimmedReason) {
+    ElMessage.warning('请填写举报理由')
+    return
+  }
+
+  submitting.value = true
+  const result = await reportApi.submit({
+    reporterId: userStore.id,
+    reporterName: userStore.username,
+    reporterAvatar: userStore.avatar,
+    targetType: props.targetType,
+    targetId: props.targetId,
+    reason: trimmedReason,
+    details: details.value.trim(),
+    context: {
+      ...props.context,
+      targetLabel: props.targetLabel || props.context?.targetLabel,
+      sourcePath: route.fullPath,
+    },
+  })
+  submitting.value = false
+
+  if (!result.success) {
+    ElMessage.error(result.message || '举报提交失败')
+    return
+  }
+
+  ElMessage.success('举报已提交')
+  emit('submitted')
+  close()
+}
+</script>
+
+<style scoped>
+.report-form {
+  text-align: left;
+}
+
+.report-form :deep(.el-select) {
+  width: 100%;
+}
+</style>

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -40,6 +40,15 @@
             <el-icon><Document /></el-icon>
             <span>规则审核</span>
           </router-link>
+          <router-link
+            v-if="userStore.isAdmin"
+            to="/admin/reports-review"
+            class="nav-item"
+            exact-active-class="active"
+          >
+            <el-icon><Warning /></el-icon>
+            <span>举报审核</span>
+          </router-link>
         </nav>
         <div class="sidebar-bottom">
           <div class="user-avatar">
@@ -62,6 +71,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import { Warning } from '@element-plus/icons-vue'
 import { storeToRefs } from 'pinia'
 import { useRouter } from 'vue-router'
 import { useUserStore } from '../stores/userStore'

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -21,6 +21,7 @@ import RuleMarketDetailView from '../views/RuleMarketDetailView.vue'
 import RuleDeveloperDetailView from '../views/RuleDeveloperDetailView.vue'
 import RuleRoomSearchView from '../views/RuleRoomSearchView.vue'
 import AdminRuleReviewView from '../views/AdminRuleReviewView.vue'
+import AdminReportReviewView from '../views/AdminReportReviewView.vue'
 import { ElMessage } from 'element-plus'
 import { roomApi, getRoomEntryPath } from '../api/room'
 import { useUserStore } from '../stores/userStore'
@@ -94,6 +95,10 @@ const routes: RouteRecordRaw[] = [
       {
         path: 'admin/rules-review',
         component: AdminRuleReviewView
+      },
+      {
+        path: 'admin/reports-review',
+        component: AdminReportReviewView
       },
       {
         // 审核员的可视化预览模式：与作者编辑共用 RuleBuilderView 组件，由组件内部根据 route.path 切到 readonly。

--- a/src/views/AdminReportReviewView.vue
+++ b/src/views/AdminReportReviewView.vue
@@ -1,0 +1,246 @@
+<template>
+  <div class="admin-report-page">
+    <header class="report-header">
+      <div>
+        <h1>举报审核</h1>
+        <p>查看玩家、规则和评价举报，处理封禁或驳回操作。</p>
+      </div>
+      <div class="header-actions">
+        <el-tag type="danger" size="large">待处理 {{ pendingCount }}</el-tag>
+        <el-button :loading="loading" @click="loadReports">刷新</el-button>
+      </div>
+    </header>
+
+    <section class="filter-bar">
+      <el-select v-model="filters.status" placeholder="状态">
+        <el-option label="全部状态" value="all" />
+        <el-option label="待处理" value="pending" />
+        <el-option label="已处理" value="resolved" />
+        <el-option label="已驳回" value="rejected" />
+      </el-select>
+      <el-select v-model="filters.targetType" placeholder="举报类型">
+        <el-option label="全部类型" value="all" />
+        <el-option label="用户" value="user" />
+        <el-option label="规则" value="rule" />
+        <el-option label="评价" value="review" />
+        <el-option label="对局行为" value="player_behavior" />
+      </el-select>
+      <el-input
+        v-model="filters.keyword"
+        clearable
+        placeholder="搜索目标、理由或说明"
+        @keyup.enter="loadReports"
+        @clear="loadReports"
+      />
+      <el-button type="primary" @click="loadReports">筛选</el-button>
+    </section>
+
+    <div v-if="loading && reports.length === 0" class="empty-state">正在加载举报列表...</div>
+    <el-empty v-else-if="!loading && reports.length === 0" description="暂无举报记录" />
+
+    <div v-else class="report-layout">
+      <aside class="report-list">
+        <ReportListItem
+          v-for="report in reports"
+          :key="report.id"
+          :report="report"
+          :active="selectedId === report.id"
+          @select="selectReport(report.id)"
+        />
+      </aside>
+
+      <AdminReportDetail
+        :report="selectedReport"
+        @action="handleAction"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref } from 'vue'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import { reportApi, type Report, type ReportAction, type ReportQuery } from '../api/report'
+import ReportListItem from '../components/report/ReportListItem.vue'
+import AdminReportDetail from '../components/report/AdminReportDetail.vue'
+
+const loading = ref(false)
+const reports = ref<Report[]>([])
+const selectedId = ref('')
+const pendingCount = ref(0)
+const filters = reactive<ReportQuery>({
+  status: 'pending',
+  targetType: 'all',
+  keyword: '',
+})
+
+const selectedReport = computed(() => reports.value.find((report) => report.id === selectedId.value) || null)
+
+function selectReport(reportId: string) {
+  selectedId.value = reportId
+}
+
+async function loadCounts() {
+  const result = await reportApi.counts()
+  if (result.success) {
+    pendingCount.value = result.data?.pending || 0
+  }
+}
+
+async function loadReports() {
+  loading.value = true
+  const result = await reportApi.list(filters)
+  loading.value = false
+
+  if (!result.success) {
+    ElMessage.error(result.message || '举报列表加载失败')
+    return
+  }
+
+  reports.value = result.data || []
+  if (selectedId.value && !reports.value.some((report) => report.id === selectedId.value)) {
+    selectedId.value = ''
+  }
+  if (!selectedId.value && reports.value.length > 0) {
+    selectedId.value = reports.value[0].id
+  }
+  await loadCounts()
+}
+
+async function handleAction(action: ReportAction) {
+  if (!selectedReport.value) return
+
+  const actionText = action === 'ban_user' ? '封禁用户' : action === 'ban_rule' ? '封禁规则' : '驳回举报'
+  let note = ''
+  try {
+    const result = await ElMessageBox.prompt(
+      `确认执行“${actionText}”吗？请填写处理备注。`,
+      actionText,
+      {
+        confirmButtonText: '确认',
+        cancelButtonText: '取消',
+        inputType: 'textarea',
+        inputPlaceholder: '处理说明',
+        inputValidator: (value: string) => {
+          if ((value || '').trim().length > 300) return '备注不能超过 300 字'
+          return true
+        },
+      },
+    )
+    note = (result.value || '').trim()
+  } catch {
+    return
+  }
+
+  const result = await reportApi.action(selectedReport.value.id, {
+    action,
+    note,
+    params: {
+      targetType: selectedReport.value.targetType,
+      targetId: selectedReport.value.targetId,
+    },
+  })
+
+  if (!result.success) {
+    ElMessage.error(result.message || '处理失败')
+    return
+  }
+
+  ElMessage.success('处理完成')
+  await loadReports()
+}
+
+onMounted(() => {
+  void loadReports()
+})
+</script>
+
+<style scoped>
+.admin-report-page {
+  min-height: 100%;
+  padding: 28px;
+  background: #f5f6fa;
+  color: #252633;
+  text-align: left;
+}
+
+.report-header,
+.filter-bar,
+.empty-state {
+  border: 1px solid #dfe3ec;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.report-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 22px 24px;
+  margin-bottom: 16px;
+}
+
+.report-header h1 {
+  margin: 0;
+  font-size: 26px;
+  letter-spacing: 0;
+}
+
+.report-header p {
+  margin: 6px 0 0;
+  color: #4a5063;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.filter-bar {
+  display: grid;
+  grid-template-columns: 150px 170px minmax(240px, 1fr) auto;
+  gap: 12px;
+  padding: 16px;
+  margin-bottom: 16px;
+}
+
+.empty-state {
+  padding: 36px;
+  text-align: center;
+  color: #4a5063;
+}
+
+.report-layout {
+  display: grid;
+  grid-template-columns: minmax(320px, 0.42fr) minmax(0, 1fr);
+  gap: 16px;
+  align-items: start;
+}
+
+.report-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: calc(100vh - 245px);
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+@media (max-width: 980px) {
+  .report-header,
+  .filter-bar,
+  .report-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .report-header {
+    display: grid;
+  }
+
+  .report-list {
+    max-height: none;
+  }
+}
+</style>

--- a/src/views/BattleView.vue
+++ b/src/views/BattleView.vue
@@ -19,13 +19,27 @@
           v-for="player in opponents"
           :key="player.id"
           class="player-card"
-          :class="{ active: currentTurnPlayerId === player.id }"
+          :class="{ active: currentTurnPlayerId === player.id, selected: selectedOpponentId === player.id }"
+          role="button"
+          tabindex="0"
+          @click="toggleSelectedOpponent(player.id)"
+          @keydown.enter.prevent="toggleSelectedOpponent(player.id)"
         >
           <div class="player-avatar">{{ player.name.slice(0, 1) }}</div>
           <div class="mini-back" :style="backCardStyle">
             <div v-if="!cardStyle.backImage" class="mini-back-inner"></div>
           </div>
           <div class="card-count">{{ player.cardCount }}</div>
+          <ReportButton
+            v-if="selectedOpponentId === player.id"
+            class="battle-report"
+            target-type="player_behavior"
+            :target-id="player.id"
+            :target-label="player.name"
+            tooltip="举报对局行为"
+            small
+            :context="{ roomCode: snapshot?.roomCode, sessionId: snapshot?.sessionId, ruleId: snapshot?.ruleId, targetLabel: player.name }"
+          />
         </div>
       </div>
     </div>
@@ -94,6 +108,7 @@ import { ElMessage } from 'element-plus'
 import { gameApi, type GameSnapshot } from '../api/game'
 import { roomApi } from '../api/room'
 import { replayApi } from '../api/replay'
+import ReportButton from '../components/report/ReportButton.vue'
 
 type CardStyle = {
   fontFamily: string
@@ -114,6 +129,7 @@ const storageKey = 'wildcard-card-style'
 const currentPlayerId = roomApi.getCurrentPlayerId()
 const snapshot = ref<GameSnapshot | null>(null)
 const selectedCardIds = ref<string[]>([])
+const selectedOpponentId = ref('')
 const actionLoading = ref(false)
 const isLeavingBattle = ref(false)
 const showSettlementNotice = ref(false)
@@ -265,6 +281,9 @@ async function refreshSnapshot() {
   }
 
   snapshot.value = result.data
+  if (selectedOpponentId.value && !result.data.players.some((player) => player.id === selectedOpponentId.value)) {
+    selectedOpponentId.value = ''
+  }
   selectedCardIds.value = selectedCardIds.value.filter((cardId) => (
     result.data?.handCards.some((card) => card.id === cardId)
   ))
@@ -295,6 +314,10 @@ function scheduleReadyRoomRedirect() {
     settlementTimer = null
     void returnToReadyRoom()
   }, SETTLEMENT_REDIRECT_DELAY_MS)
+}
+
+function toggleSelectedOpponent(playerId: string) {
+  selectedOpponentId.value = selectedOpponentId.value === playerId ? '' : playerId
 }
 
 async function playSelectedCards() {
@@ -447,6 +470,7 @@ onBeforeUnmount(() => {
 }
 
 .player-card {
+  position: relative;
   flex: 0 0 320px;
   height: 108px;
   display: flex;
@@ -458,10 +482,21 @@ onBeforeUnmount(() => {
   background: #f4f5f8;
 }
 
+.battle-report {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+}
+
 .player-card.active,
 .user-info.active {
   border-color: #8d79d6;
   box-shadow: 0 0 0 3px rgba(141, 121, 214, 0.18);
+}
+
+.player-card.selected {
+  border-color: #d46b6b;
+  box-shadow: 0 0 0 3px rgba(212, 107, 107, 0.16);
 }
 
 .player-avatar,

--- a/src/views/ReadyRoomView.vue
+++ b/src/views/ReadyRoomView.vue
@@ -31,7 +31,11 @@
           v-for="player in room.players"
           :key="player.id"
           class="player-box"
-          :class="{ current: player.id === currentPlayerId }"
+          :class="{ current: player.id === currentPlayerId, selected: selectedPlayerId === player.id }"
+          role="button"
+          tabindex="0"
+          @click="toggleSelectedPlayer(player.id)"
+          @keydown.enter.prevent="toggleSelectedPlayer(player.id)"
         >
           <img
             :src="player.avatar || DEFAULT_AVATAR"
@@ -43,6 +47,16 @@
           <div class="player-status" :class="{ ready: player.isReady }">
             {{ player.id === room.hostId ? '房主' : player.isReady ? '准备' : '未准备' }}
           </div>
+          <ReportButton
+            v-if="player.id !== currentPlayerId && selectedPlayerId === player.id"
+            class="player-report"
+            target-type="user"
+            :target-id="player.id"
+            :target-label="player.username"
+            tooltip="举报玩家"
+            small
+            :context="{ roomCode: room.code, targetLabel: player.username }"
+          />
         </article>
 
         <article
@@ -85,6 +99,7 @@ import { ElMessage } from 'element-plus'
 import { storeToRefs } from 'pinia'
 import { roomApi, DEFAULT_AVATAR, getRoomEntryPath, type Room } from '../api/room'
 import { useUserStore } from '../stores/userStore'
+import ReportButton from '../components/report/ReportButton.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -93,6 +108,7 @@ const { username, avatar } = storeToRefs(userStore)
 const currentPlayerId = roomApi.getCurrentPlayerId()
 const room = ref<Room | null>(null)
 const actionLoading = ref(false)
+const selectedPlayerId = ref('')
 let pollingTimer: number | null = null
 const currentPlayer = computed(() => room.value?.players.find((player) => player.id === currentPlayerId) || null)
 
@@ -141,6 +157,9 @@ async function refreshRoom() {
 
   room.value = result.data
   syncCurrentPlayerProfile()
+  if (selectedPlayerId.value && !room.value.players.some((player) => player.id === selectedPlayerId.value)) {
+    selectedPlayerId.value = ''
+  }
 
   if (!room.value.players.some((player) => player.id === currentPlayerId)) {
     stopPolling()
@@ -209,6 +228,14 @@ function stopPolling() {
     window.clearInterval(pollingTimer)
     pollingTimer = null
   }
+}
+
+function toggleSelectedPlayer(playerId: string) {
+  if (playerId === currentPlayerId) {
+    selectedPlayerId.value = ''
+    return
+  }
+  selectedPlayerId.value = selectedPlayerId.value === playerId ? '' : playerId
 }
 
 onMounted(async () => {
@@ -327,6 +354,7 @@ onBeforeUnmount(() => {
 }
 
 .player-box {
+  position: relative;
   min-height: 180px;
   padding: 24px 18px;
   border: 1px solid #d7dbe7;
@@ -339,9 +367,20 @@ onBeforeUnmount(() => {
   text-align: center;
 }
 
+.player-report {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+}
+
 .player-box.current {
   border-color: #ab99af;
   box-shadow: 0 8px 20px rgba(171, 153, 175, 0.16);
+}
+
+.player-box.selected {
+  border-color: #d46b6b;
+  box-shadow: 0 8px 20px rgba(159, 47, 47, 0.12);
 }
 
 .player-box.empty {

--- a/src/views/RuleDeveloperDetailView.vue
+++ b/src/views/RuleDeveloperDetailView.vue
@@ -6,6 +6,15 @@
         <h1>{{ developerName }}</h1>
         <p>{{ developerBio }}</p>
       </div>
+      <ReportButton
+        v-if="developerId"
+        class="developer-report"
+        target-type="user"
+        :target-id="developerId"
+        :target-label="developerName"
+        tooltip="举报作者"
+        :context="{ targetLabel: developerName }"
+      />
     </header>
 
     <section class="search-panel">
@@ -54,6 +63,7 @@ import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { ElMessage } from 'element-plus'
 import { marketApi, resolveDeveloperAvatar, type PublishedRuleSummary } from '../api/market'
+import ReportButton from '../components/report/ReportButton.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -110,11 +120,16 @@ onMounted(() => {
 }
 
 .developer-header {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 16px;
   padding: 22px 24px;
   margin-bottom: 16px;
+}
+
+.developer-report {
+  margin-left: auto;
 }
 
 .developer-header img {

--- a/src/views/RuleMarketDetailView.vue
+++ b/src/views/RuleMarketDetailView.vue
@@ -7,6 +7,14 @@
           <div class="title-line">
             <h1>{{ rule.name }}</h1>
             <el-tag>{{ rule.type }}</el-tag>
+            <ReportButton
+              target-type="rule"
+              :target-id="rule.id"
+              :target-label="rule.name"
+              tooltip="举报规则"
+              small
+              :context="{ ruleId: rule.id, targetLabel: rule.name }"
+            />
           </div>
           <div class="rating-line">
             <el-rate :model-value="rule.rating" disabled allow-half />
@@ -23,6 +31,15 @@
         <section class="screenshot-panel panel">
           <img v-if="coverImage" :src="resolveImageUrl(coverImage)" :alt="rule.name">
           <div v-else class="screenshot-placeholder">{{ rule.type }}</div>
+          <ReportButton
+            class="asset-report"
+            target-type="rule"
+            :target-id="rule.id"
+            :target-label="`${rule.name} 的图形资源`"
+            tooltip="举报图形资源"
+            small
+            :context="{ ruleId: rule.id, targetLabel: `${rule.name} 的图形资源` }"
+          />
         </section>
         <section class="intro-panel panel">
           <h2>玩法介绍</h2>
@@ -88,6 +105,14 @@
               <strong>{{ review.authorName }}</strong>
               <el-rate :model-value="review.rating" disabled size="small" />
               <span>{{ formatDate(review.createdAt) }}</span>
+              <ReportButton
+                target-type="review"
+                :target-id="review.id"
+                :target-label="`${rule.name} 的评价`"
+                tooltip="举报评价"
+                small
+                :context="{ ruleId: rule.id, targetLabel: `${rule.name} 的评价` }"
+              />
             </div>
             <p>{{ review.content }}</p>
             <img v-if="review.imageUrl" :src="review.imageUrl" :alt="review.content" class="review-image">
@@ -107,6 +132,7 @@ import type { UploadFile } from 'element-plus'
 import { marketApi, resolveDeveloperAvatar, type PublishedRuleDetail } from '../api/market'
 import { getApiUrl } from '../api/config'
 import { useRuleFork } from '../composables/useRuleFork'
+import ReportButton from '../components/report/ReportButton.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -332,8 +358,15 @@ onMounted(() => {
 }
 
 .screenshot-panel {
+  position: relative;
   min-height: 320px;
   overflow: hidden;
+}
+
+.asset-report {
+  position: absolute;
+  top: 12px;
+  right: 12px;
 }
 
 .screenshot-panel img {


### PR DESCRIPTION
## 变更内容

- 新增举报审核页面`AdminReportReviewView.vue`
- 新增举报相关组件`src/components/report/*`
- 新增举报接口`report.ts`
- 修改`MainLayout.vue`和`index.ts`，增加管理员视角下到举报审核页面的路由
- 在准备房间页面`ReadyRoomView.vue`，对战页面`BattleView.vue`，规则详情页面`RuleMarketDetailView.vue`，规则开发者详情页面`RuleDeveloperDetailView.vue`增加了举报按钮