### PR TITLE
test: cover report UI and rule asset frontend flows

### DIFF
--- a/src/api/__tests__/game.spec.ts
+++ b/src/api/__tests__/game.spec.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { apiGet, apiPost } from '../request'
+import { gameApi } from '../game'
+import { roomApi } from '../room'
+
+vi.mock('../request', () => ({
+  apiGet: vi.fn(),
+  apiPost: vi.fn(),
+}))
+
+vi.mock('../config', () => ({
+  API_CONFIG: {
+    endpoints: {
+      game: { getCurrent: '/api/games/current' },
+    },
+  },
+  shouldUseGameMockApi: () => false,
+}))
+
+vi.mock('../room', () => ({
+  buildRoomHeaders: () => ({ 'X-Room-Code': 'ROOM42' }),
+  roomApi: {
+    getRoomByCode: vi.fn(),
+    getCurrentPlayerId: vi.fn(),
+  },
+}))
+
+describe('gameApi assets normalization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(roomApi.getCurrentPlayerId).mockReturnValue('player-1')
+    vi.mocked(roomApi.getRoomByCode).mockResolvedValue({
+      success: true,
+      data: {
+        id: 'room-id-42',
+        code: 'ROOM42',
+        hostId: 'player-1',
+        playerCount: 2,
+        ruleId: 'rule-asset-demo',
+        ruleName: 'Asset Demo',
+        roundTime: 45,
+        password: null,
+        status: 'playing',
+        players: [
+          { id: 'player-1', username: 'Alice', avatar: '/alice.png', isReady: true },
+          { id: 'player-2', username: 'Bob', avatar: '/bob.png', isReady: true },
+        ],
+      },
+    })
+  })
+
+  it('keeps backend rule_assets on normalized current-game snapshots', async () => {
+    vi.mocked(apiGet).mockResolvedValue({
+      success: true,
+      data: {
+        id: 'session-1',
+        room_code: 'ROOM42',
+        status: 'playing',
+        table: { player_index: 0 },
+        players: [{ id: 'player-1' }, { id: 'player-2' }],
+        hands: {
+          'player-1': [{ id: 'c-1', properties: { 点数: 1, 花色: 0 } }],
+        },
+        pending_action: { id: 'action-1', player_id: 'player-1', timer: 30 },
+        rule_assets: {
+          card_faces: {
+            '%E7%82%B9%E6%95%B0=1&%E8%8A%B1%E8%89%B2=0': {
+              properties: { 点数: 1, 花色: 0 },
+              image_url: '/static/rule-assets/ace-spade.png',
+            },
+          },
+          card_back: '/static/rule-assets/back.png',
+          background: '/static/rule-assets/table.png',
+        },
+      },
+    })
+
+    const result = await gameApi.getCurrent('ROOM42')
+
+    expect(apiGet).toHaveBeenCalledWith(
+      '/api/games/current?roomCode=ROOM42',
+      expect.objectContaining({ useMock: false, headers: { 'X-Room-Code': 'ROOM42' } }),
+    )
+    expect(result.success).toBe(true)
+    expect(result.data?.assets).toEqual({
+      card_faces: {
+        '%E7%82%B9%E6%95%B0=1&%E8%8A%B1%E8%89%B2=0': {
+          properties: { 点数: 1, 花色: 0 },
+          image_url: '/static/rule-assets/ace-spade.png',
+        },
+      },
+      card_back: '/static/rule-assets/back.png',
+      background: '/static/rule-assets/table.png',
+    })
+  })
+
+  it('preserves already-normalized assets returned after play-card actions', async () => {
+    vi.mocked(apiPost).mockResolvedValue({
+      success: true,
+      data: {
+        sessionId: 'session-1',
+        roomCode: 'ROOM42',
+        ruleId: 'rule-asset-demo',
+        status: 'playing',
+        currentPlayerId: 'player-1',
+        roundTime: 45,
+        deadlineAt: null,
+        players: [],
+        table: { playedCards: [] },
+        handCards: [],
+        pendingAction: null,
+        lastAction: null,
+        winnerIds: [],
+        assets: {
+          card_back: '/static/rule-assets/back.png',
+          background: '/static/rule-assets/table.png',
+        },
+      },
+    })
+
+    const result = await gameApi.playCards('session-1', 'action-1', ['c-1'])
+
+    expect(apiPost).toHaveBeenCalledWith(
+      '/api/games/session-1/actions/action-1/play-cards',
+      { cardIds: ['c-1'] },
+      expect.objectContaining({ useMock: false, headers: { 'X-Room-Code': 'ROOM42' } }),
+    )
+    expect(result.data?.assets?.background).toBe('/static/rule-assets/table.png')
+  })
+})

--- a/src/api/__tests__/report.spec.ts
+++ b/src/api/__tests__/report.spec.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { apiGet, apiPost } from '../request'
+import { reportApi, type Report } from '../report'
+
+vi.mock('../request', () => ({
+  apiGet: vi.fn(),
+  apiPost: vi.fn(),
+}))
+
+const storageKey = 'wildcard:default:mock-reports'
+
+const pendingReport: Report = {
+  id: 'report-pending',
+  reporterId: 'u-1',
+  reporterName: 'Alice',
+  targetType: 'player_behavior',
+  targetId: 'room-42',
+  reason: '恶意拖延',
+  details: '最后一轮持续不操作',
+  status: 'pending',
+  createdAt: 1700000002000,
+  updatedAt: 1700000002000,
+  context: { targetLabel: '房间 42 的 Bob', sourcePath: '/battle/room-42' },
+}
+
+const resolvedReport: Report = {
+  id: 'report-resolved',
+  reporterId: 'u-2',
+  reporterName: 'Carol',
+  targetType: 'rule',
+  targetId: 'rule-9',
+  reason: '疑似抄袭',
+  details: '规则描述高度相似',
+  status: 'resolved',
+  createdAt: 1700000001000,
+  updatedAt: 1700000001000,
+}
+
+function seedLocalReports(reports: Report[]) {
+  window.localStorage.setItem(storageKey, JSON.stringify(reports))
+}
+
+describe('reportApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.restoreAllMocks()
+    window.localStorage.clear()
+    window.sessionStorage.clear()
+  })
+
+  it('lists reports through the backend with encoded filters and without all sentinels', async () => {
+    vi.mocked(apiGet).mockResolvedValue({ success: true, data: [] })
+
+    await reportApi.list({
+      status: 'all',
+      targetType: 'player_behavior',
+      keyword: 'room 42 & Bob',
+      page: 2,
+    })
+
+    expect(apiGet).toHaveBeenCalledWith(
+      '/api/reports?targetType=player_behavior&keyword=room+42+%26+Bob&page=2',
+      expect.objectContaining({ useMock: false }),
+    )
+  })
+
+  it('falls back to local storage when submit backend is unavailable', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1700000003000)
+    vi.spyOn(Math, 'random').mockReturnValue(0.123456)
+    vi.mocked(apiPost).mockResolvedValue({ success: false, message: 'Not Found' })
+
+    const result = await reportApi.submit({
+      reporterId: 'spoofed-reporter',
+      reporterName: 'Alice',
+      reporterAvatar: '/avatar.png',
+      targetType: 'rule',
+      targetId: 'rule-1',
+      reason: '违规素材',
+      details: '封面包含不合规图片',
+      context: { targetLabel: '规则 A', sourcePath: '/rule-market/rule-1' },
+    })
+
+    expect(apiPost).toHaveBeenCalledWith(
+      '/api/reports',
+      expect.objectContaining({ reporterId: 'spoofed-reporter', targetId: 'rule-1' }),
+      expect.objectContaining({ useMock: false }),
+    )
+    expect(result.success).toBe(true)
+    expect(result.data).toMatchObject({
+      id: 'report-1700000003000-4fzyo8',
+      status: 'pending',
+      targetType: 'rule',
+      targetId: 'rule-1',
+    })
+    expect(JSON.parse(window.localStorage.getItem(storageKey) || '[]')).toHaveLength(1)
+  })
+
+  it('filters and sorts local fallback reports by status, type, and keyword', async () => {
+    vi.mocked(apiGet).mockResolvedValue({ success: false })
+    seedLocalReports([resolvedReport, pendingReport])
+
+    const result = await reportApi.list({
+      status: 'pending',
+      targetType: 'player_behavior',
+      keyword: 'bob',
+    })
+
+    expect(result).toEqual({ success: true, data: [pendingReport] })
+  })
+
+  it('uses local fallback for detail, counts, and action status mapping', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1700000004000)
+    vi.mocked(apiGet).mockResolvedValue({ success: false })
+    vi.mocked(apiPost).mockResolvedValue({ success: false })
+    seedLocalReports([pendingReport, resolvedReport])
+
+    await expect(reportApi.get('report-pending')).resolves.toEqual({ success: true, data: pendingReport })
+    await expect(reportApi.counts()).resolves.toEqual({ success: true, data: { pending: 1 } })
+
+    const dismissed = await reportApi.action('report-pending', {
+      action: 'dismiss',
+      note: '证据不足',
+      params: { targetType: 'player_behavior', targetId: 'room-42' },
+    })
+
+    expect(apiPost).toHaveBeenCalledWith(
+      '/api/reports/report-pending/action',
+      expect.objectContaining({ action: 'dismiss' }),
+      expect.objectContaining({ useMock: false }),
+    )
+    expect(dismissed.success).toBe(true)
+    expect(dismissed.data).toMatchObject({
+      status: 'rejected',
+      updatedAt: 1700000004000,
+      actionLog: [expect.objectContaining({ action: 'dismiss', operatorId: 'admin', note: '证据不足' })],
+    })
+    expect(JSON.parse(window.localStorage.getItem(storageKey) || '[]')[0].status).toBe('rejected')
+  })
+})

--- a/src/components/report/__tests__/ReportModal.spec.ts
+++ b/src/components/report/__tests__/ReportModal.spec.ts
@@ -1,0 +1,174 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ElMessage } from 'element-plus'
+import { reportApi } from '../../../api/report'
+import { useUserStore } from '../../../stores/userStore'
+import ReportButton from '../ReportButton.vue'
+import ReportModal from '../ReportModal.vue'
+
+const pushMock = vi.fn()
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ fullPath: '/battle/room-42' }),
+  useRouter: () => ({ push: pushMock }),
+}))
+
+vi.mock('../../../api/report', async () => {
+  const actual = await vi.importActual<typeof import('../../../api/report')>('../../../api/report')
+  return {
+    ...actual,
+    reportApi: {
+      submit: vi.fn(),
+    },
+  }
+})
+
+vi.mock('element-plus', async () => {
+  const actual = await vi.importActual<typeof import('element-plus')>('element-plus')
+  return {
+    ...actual,
+    ElMessage: {
+      success: vi.fn(),
+      error: vi.fn(),
+      warning: vi.fn(),
+      info: vi.fn(),
+    },
+  }
+})
+
+const stubs = {
+  ElDialog: {
+    props: ['modelValue'],
+    emits: ['update:modelValue', 'closed'],
+    template: '<div v-if="modelValue" class="dialog"><slot /><footer><slot name="footer" /></footer></div>',
+  },
+  ElForm: { template: '<form><slot /></form>' },
+  ElFormItem: { props: ['label'], template: '<label><span>{{ label }}</span><slot /></label>' },
+  ElInput: {
+    props: ['modelValue', 'type'],
+    emits: ['update:modelValue'],
+    template: `
+      <textarea
+        v-if="type === 'textarea'"
+        :value="modelValue"
+        @input="$emit('update:modelValue', $event.target.value)"
+      />
+      <input
+        v-else
+        :value="modelValue"
+        @input="$emit('update:modelValue', $event.target.value)"
+      />
+    `,
+  },
+  ElButton: {
+    props: ['loading', 'disabled'],
+    emits: ['click'],
+    template: '<button type="button" :disabled="disabled || loading" @click="$emit(\'click\')"><slot /></button>',
+  },
+  ElTooltip: { template: '<span><slot /></span>' },
+  ElIcon: { template: '<span><slot /></span>' },
+  Warning: true,
+}
+
+describe('report components', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    sessionStorage.clear()
+    setActivePinia(createPinia())
+    vi.mocked(reportApi.submit).mockResolvedValue({ success: true, data: undefined })
+  })
+
+  it('redirects anonymous users to login instead of opening the modal', async () => {
+    const wrapper = mount(ReportButton, {
+      props: {
+        targetType: 'rule',
+        targetId: 'rule-1',
+        targetLabel: '规则 A',
+        tooltip: '举报规则',
+      },
+      global: { stubs },
+    })
+
+    await wrapper.find('button').trigger('click')
+
+    expect(ElMessage.warning).toHaveBeenCalledWith('请先登录后再提交举报')
+    expect(pushMock).toHaveBeenCalledWith('/user-info')
+    expect(wrapper.emitted('opened')).toBeUndefined()
+  })
+
+  it('opens the modal for logged-in users', async () => {
+    useUserStore().setUser({
+      id: 'u-1',
+      username: 'Alice',
+      email: 'alice@example.com',
+      avatar: '',
+    })
+    const wrapper = mount(ReportButton, {
+      props: { targetType: 'user', targetId: 'u-2', tooltip: '举报用户' },
+      global: { stubs },
+    })
+
+    await wrapper.find('button').trigger('click')
+
+    expect(wrapper.find('.dialog').exists()).toBe(true)
+    expect(wrapper.emitted('opened')).toHaveLength(1)
+  })
+
+  it('submits a trimmed report payload with route source path and emits close events', async () => {
+    useUserStore().setUser({
+      id: 'u-1',
+      username: 'Alice',
+      email: 'alice@example.com',
+      avatar: '/avatar.png',
+    })
+    const wrapper = mount(ReportModal, {
+      props: {
+        modelValue: true,
+        targetType: 'player_behavior',
+        targetId: 'room-42:u-2',
+        targetLabel: 'Bob 的对局行为',
+        context: { roomCode: '42', sessionId: 's-1' },
+      },
+      global: { stubs },
+    })
+
+    const textareas = wrapper.findAll('textarea')
+    await textareas[0].setValue('  恶意拖延  ')
+    await textareas[1].setValue('  最后一轮持续不操作  ')
+    await wrapper.findAll('button').find(button => button.text() === '提交举报')?.trigger('click')
+    await flushPromises()
+
+    expect(reportApi.submit).toHaveBeenCalledWith({
+      reporterId: 'u-1',
+      reporterName: 'Alice',
+      reporterAvatar: '/avatar.png',
+      targetType: 'player_behavior',
+      targetId: 'room-42:u-2',
+      reason: '恶意拖延',
+      details: '最后一轮持续不操作',
+      context: {
+        roomCode: '42',
+        sessionId: 's-1',
+        targetLabel: 'Bob 的对局行为',
+        sourcePath: '/battle/room-42',
+      },
+    })
+    expect(ElMessage.success).toHaveBeenCalledWith('举报已提交')
+    expect(wrapper.emitted('submitted')).toHaveLength(1)
+    expect(wrapper.emitted('update:modelValue')).toEqual([[false]])
+  })
+
+  it('blocks blank reasons before calling the API', async () => {
+    const wrapper = mount(ReportModal, {
+      props: { modelValue: true, targetType: 'rule', targetId: 'rule-1' },
+      global: { stubs },
+    })
+
+    await wrapper.findAll('button').find(button => button.text() === '提交举报')?.trigger('click')
+
+    expect(reportApi.submit).not.toHaveBeenCalled()
+    expect(ElMessage.warning).toHaveBeenCalledWith('请填写举报理由')
+  })
+})

--- a/src/utils/__tests__/ruleBuilder.spec.ts
+++ b/src/utils/__tests__/ruleBuilder.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createInitialDesign,
+  exportRuleDesign,
+  getCardFaceAssetKey,
+  importRuleDesign,
+} from '../ruleBuilder'
+
+describe('ruleBuilder assets', () => {
+  it('exports card faces, card back, and background assets using backend field names', () => {
+    const design = createInitialDesign()
+    const faceKey = getCardFaceAssetKey({ 点数: 1, 花色: 0 })
+    design.assets.cardFaces[faceKey] = {
+      properties: { 点数: 1, 花色: 0 },
+      imageUrl: '/static/rule-assets/ace-spade.png',
+    }
+    design.assets.cardBack = '/static/rule-assets/back.png'
+    design.assets.background = '/static/rule-assets/table.png'
+
+    const exported = exportRuleDesign(design)
+
+    expect(exported.assets).toEqual({
+      card_faces: {
+        [faceKey]: {
+          properties: { 点数: 1, 花色: 0 },
+          image_url: '/static/rule-assets/ace-spade.png',
+        },
+      },
+      card_back: '/static/rule-assets/back.png',
+      background: '/static/rule-assets/table.png',
+    })
+  })
+
+  it('imports backend assets and ignores card face entries without images', () => {
+    const imported = importRuleDesign({
+      classes: {},
+      cardsets: {},
+      cardset_comparisons: {},
+      match_flow: {},
+      end_flow: {},
+      assets: {
+        card_faces: {
+          valid: {
+            properties: { 点数: 13, 花色: 3 },
+            image_url: '/static/rule-assets/king-diamond.png',
+          },
+          empty: {
+            properties: { 点数: 1, 花色: 0 },
+            image_url: '',
+          },
+        },
+        card_back: '/static/rule-assets/back.png',
+        background: '/static/rule-assets/table.png',
+      },
+    })
+
+    expect(imported.assets.cardBack).toBe('/static/rule-assets/back.png')
+    expect(imported.assets.background).toBe('/static/rule-assets/table.png')
+    expect(imported.assets.cardFaces).toEqual({
+      valid: {
+        properties: { 点数: 13, 花色: 3 },
+        imageUrl: '/static/rule-assets/king-diamond.png',
+      },
+    })
+  })
+})

--- a/src/views/__tests__/AdminReportReviewView.spec.ts
+++ b/src/views/__tests__/AdminReportReviewView.spec.ts
@@ -1,0 +1,190 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import { reportApi, type Report } from '../../api/report'
+import AdminReportDetail from '../../components/report/AdminReportDetail.vue'
+import AdminReportReviewView from '../AdminReportReviewView.vue'
+
+vi.mock('../../api/report', async () => {
+  const actual = await vi.importActual<typeof import('../../api/report')>('../../api/report')
+  return {
+    ...actual,
+    reportApi: {
+      list: vi.fn(),
+      counts: vi.fn(),
+      action: vi.fn(),
+    },
+  }
+})
+
+vi.mock('element-plus', async () => {
+  const actual = await vi.importActual<typeof import('element-plus')>('element-plus')
+  return {
+    ...actual,
+    ElMessage: {
+      success: vi.fn(),
+      error: vi.fn(),
+      warning: vi.fn(),
+      info: vi.fn(),
+    },
+    ElMessageBox: {
+      prompt: vi.fn(),
+    },
+  }
+})
+
+const reports: Report[] = [
+  {
+    id: 'report-1',
+    reporterId: 'u-1',
+    reporterName: 'Alice',
+    reporterAvatar: '/avatar.png',
+    targetType: 'player_behavior',
+    targetId: 'room-42:u-2',
+    reason: '恶意拖延',
+    details: '最后一轮持续不操作',
+    status: 'pending',
+    createdAt: 1700000000000,
+    updatedAt: 1700000000000,
+    context: { targetLabel: 'Bob 的对局行为', sourcePath: '/battle/room-42' },
+  },
+  {
+    id: 'report-2',
+    reporterId: 'u-3',
+    reporterName: 'Carol',
+    targetType: 'rule',
+    targetId: 'rule-9',
+    reason: '疑似抄袭',
+    details: '',
+    status: 'pending',
+    createdAt: 1700000100000,
+    updatedAt: 1700000100000,
+  },
+]
+
+const buttonStub = {
+  props: ['loading', 'disabled', 'type'],
+  emits: ['click'],
+  template: '<button type="button" :disabled="disabled || loading" @click="$emit(\'click\')"><slot /></button>',
+}
+
+const stubs = {
+  ElButton: buttonStub,
+  ElTag: { props: ['type'], template: '<span class="tag"><slot /></span>' },
+  ElSelect: {
+    props: ['modelValue'],
+    emits: ['update:modelValue'],
+    template: '<select :value="modelValue" @change="$emit(\'update:modelValue\', $event.target.value)"><slot /></select>',
+  },
+  ElOption: { props: ['label', 'value'], template: '<option :value="value">{{ label }}</option>' },
+  ElInput: {
+    props: ['modelValue'],
+    emits: ['update:modelValue', 'clear'],
+    template: '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+  },
+  ElEmpty: { props: ['description'], template: '<div class="empty">{{ description }}</div>' },
+}
+
+function mountView() {
+  return mount(AdminReportReviewView, { global: { stubs } })
+}
+
+describe('AdminReportReviewView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(reportApi.list).mockResolvedValue({ success: true, data: reports.map(report => ({ ...report })) })
+    vi.mocked(reportApi.counts).mockResolvedValue({ success: true, data: { pending: 2 } })
+    vi.mocked(reportApi.action).mockResolvedValue({ success: true, data: { ...reports[0], status: 'resolved' } })
+  })
+
+  it('loads pending reports, selects the first report, and displays pending count', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(reportApi.list).toHaveBeenCalledWith({ status: 'pending', targetType: 'all', keyword: '' })
+    expect(reportApi.counts).toHaveBeenCalledTimes(1)
+    expect(wrapper.text()).toContain('待处理 2')
+    expect(wrapper.findAll('.report-list-item')).toHaveLength(2)
+    expect(wrapper.text()).toContain('Bob 的对局行为')
+    expect(wrapper.text()).toContain('/battle/room-42')
+  })
+
+  it('runs selected report actions with note and target params, then reloads', async () => {
+    vi.mocked(ElMessageBox.prompt).mockResolvedValueOnce({ value: '已核实，封禁用户', action: 'confirm' } as never)
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.findAll('.detail-actions button')[0].trigger('click')
+    await flushPromises()
+
+    expect(ElMessageBox.prompt).toHaveBeenCalledWith(
+      '确认执行“封禁用户”吗？请填写处理备注。',
+      '封禁用户',
+      expect.objectContaining({ inputType: 'textarea' }),
+    )
+    expect(reportApi.action).toHaveBeenCalledWith('report-1', {
+      action: 'ban_user',
+      note: '已核实，封禁用户',
+      params: { targetType: 'player_behavior', targetId: 'room-42:u-2' },
+    })
+    expect(ElMessage.success).toHaveBeenCalledWith('处理完成')
+    expect(reportApi.list).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not call action when the prompt is cancelled', async () => {
+    vi.mocked(ElMessageBox.prompt).mockRejectedValueOnce(new Error('cancel'))
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.findAll('.detail-actions button')[2].trigger('click')
+    await flushPromises()
+
+    expect(reportApi.action).not.toHaveBeenCalled()
+  })
+
+  it('shows an error when report list loading fails', async () => {
+    vi.mocked(reportApi.list).mockResolvedValueOnce({ success: false, message: '权限不足' })
+
+    mountView()
+    await flushPromises()
+
+    expect(ElMessage.error).toHaveBeenCalledWith('权限不足')
+  })
+})
+
+describe('AdminReportDetail', () => {
+  it('enables only user-ban actions for player behavior reports and renders action log', () => {
+    const wrapper = mount(AdminReportDetail, {
+      props: {
+        report: {
+          ...reports[0],
+          actionLog: [{ id: 'a-1', action: 'dismiss', operatorId: 'admin', note: '证据不足', createdAt: 1700000200000 }],
+        },
+      },
+      global: { stubs },
+    })
+
+    const buttons = wrapper.findAll('.detail-actions button')
+    expect(buttons[0].attributes('disabled')).toBeUndefined()
+    expect(buttons[1].attributes('disabled')).toBeDefined()
+    expect(buttons[2].attributes('disabled')).toBeUndefined()
+    expect(wrapper.text()).toContain('处理记录')
+    expect(wrapper.text()).toContain('证据不足')
+  })
+
+  it('enables only rule-ban actions for rule reports and disables all actions after resolution', async () => {
+    const wrapper = mount(AdminReportDetail, {
+      props: { report: reports[1] },
+      global: { stubs },
+    })
+
+    let buttons = wrapper.findAll('.detail-actions button')
+    expect(buttons[0].attributes('disabled')).toBeDefined()
+    expect(buttons[1].attributes('disabled')).toBeUndefined()
+    expect(buttons[2].attributes('disabled')).toBeUndefined()
+
+    await wrapper.setProps({ report: { ...reports[1], status: 'resolved' } })
+    buttons = wrapper.findAll('.detail-actions button')
+    expect(buttons.every(button => button.attributes('disabled') !== undefined)).toBe(true)
+  })
+})

--- a/src/views/__tests__/RuleDeveloperDetailView.spec.ts
+++ b/src/views/__tests__/RuleDeveloperDetailView.spec.ts
@@ -78,6 +78,7 @@ const stubs = {
   ElEmpty: { props: ['description'], template: '<div class="empty">{{ description }}</div>' },
   ElTag: { template: '<span class="tag"><slot /></span>' },
   ElRate: { props: ['modelValue'], template: '<span class="rate">{{ modelValue }}</span>' },
+  ReportButton: true,
 }
 
 function mountView() {

--- a/src/views/__tests__/RuleMarketDetailView.spec.ts
+++ b/src/views/__tests__/RuleMarketDetailView.spec.ts
@@ -82,6 +82,7 @@ const stubs = {
   ElUpload: { template: '<div class="upload"><slot /></div>' },
   ElCarousel: { template: '<div class="carousel"><slot /></div>' },
   ElCarouselItem: { template: '<div class="carousel-item"><slot /></div>' },
+  ReportButton: true,
 }
 
 function mountView() {


### PR DESCRIPTION
## Summary\n- Add reportApi fallback and endpoint contract tests.\n- Add ReportButton/ReportModal tests for login guard, payload trimming, and route source path.\n- Add AdminReportReviewView/AdminReportDetail tests for list/count/action flows and action button gating.\n- Add rule asset background import/export and game snapshot normalization tests.\n- Stub ReportButton in unrelated rule detail/developer tests so those specs stay focused and do not require Pinia.\n\n## Test Plan\n- npm ci --ignore-scripts\n- npm rebuild esbuild vue-demi\n- npm run test:unit\n- npm run build\n\nCloses #184\nCloses #183\n\n## Follow-up issues from review\n- #186 report fallback should distinguish mock/unavailable from real backend failures.\n- #185 replay persistence path should be clarified for non-mock games.\n\n## Review\n- claude-review --base main: production-risk findings recorded as #186 and #185; no test-file fix needed in this PR. Record: /home/lih/.codex/cross-agent-review/Data-erhuo-.worktrees-WildCard_FrontEnd-test-report-system-coverage/claude-code/20260612T134348Z-standard.json