### PR TITLE
test: re-enable frontend e2e coverage

### DIFF
--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -52,31 +52,30 @@ jobs:
       - name: Run unit tests
         run: npm run test:unit
 
-      # TODO: re-enable Cypress setup and E2E after the user flow and CI env are stabilized.
-      # - name: Install Cypress binary
-      #   run: |
-      #     mkdir -p "$CYPRESS_CACHE_FOLDER"
-      #     for attempt in 1 2 3; do
-      #       if npx cypress install; then
-      #         break
-      #       fi
-      #
-      #       if [ "$attempt" -eq 3 ]; then
-      #         exit 1
-      #       fi
-      #
-      #       echo "cypress install failed on attempt $attempt, retrying..."
-      #       sleep 5
-      #     done
+      - name: Install Cypress binary
+        run: |
+          mkdir -p "$CYPRESS_CACHE_FOLDER"
+          for attempt in 1 2 3; do
+            if npx cypress install; then
+              break
+            fi
 
-      # - name: Check Cypress binary
-      #   run: |
-      #     npx cypress cache path
-      #     npx cypress cache list
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
 
-      # - name: Run E2E tests
-      #   run: |
-      #     Xvfb :99 -screen 0 1280x1024x24 >/tmp/xvfb.log 2>&1 &
-      #     export DISPLAY=:99
-      #     sleep 2
-      #     npm run test:e2e
+            echo "cypress install failed on attempt $attempt, retrying..."
+            sleep 5
+          done
+
+      - name: Check Cypress binary
+        run: |
+          npx cypress cache path
+          npx cypress cache list
+
+      - name: Run E2E tests
+        run: |
+          Xvfb :99 -screen 0 1280x1024x24 >/tmp/xvfb.log 2>&1 &
+          export DISPLAY=:99
+          sleep 2
+          npm run test:e2e

--- a/cypress/e2e/admin-review.cy.ts
+++ b/cypress/e2e/admin-review.cy.ts
@@ -1,0 +1,128 @@
+/// <reference types="cypress" />
+
+import { apiResponse, stubApiPreflight, stubExternalImages, visitAs } from './helpers'
+
+const pendingDrafts = [
+  {
+    draftId: 'review-draft-1',
+    name: '待审 War 规则',
+    ownerId: 'author-1',
+    ownerName: '作者甲',
+    playerCount: 2,
+    description: '需要审核的拼点规则',
+    introduction: '每轮比较牌面点数。',
+    coverUrl: '/static/rule-images/review-cover.png',
+    screenshotUrls: ['/static/rule-images/review-shot.png'],
+    updatedAt: Date.parse('2026-06-10T13:00:00Z'),
+    design: { nodes: [{ id: 'start' }] },
+  },
+]
+
+const reports = [
+  {
+    id: 'report-1',
+    reporterId: 'player-1',
+    reporterName: '测试玩家',
+    reporterAvatar: '',
+    targetType: 'player_behavior',
+    targetId: 'room-42:bad-player',
+    reason: '恶意拖延',
+    details: '最后一轮长时间不操作',
+    status: 'pending',
+    createdAt: Date.parse('2026-06-10T14:00:00Z'),
+    updatedAt: Date.parse('2026-06-10T14:00:00Z'),
+    context: { targetLabel: 'BadPlayer 的对局行为', sourcePath: '/game/ROOM42/battle' },
+  },
+  {
+    id: 'report-2',
+    reporterId: 'player-2',
+    reporterName: '另一玩家',
+    targetType: 'rule',
+    targetId: 'rule-9',
+    reason: '疑似抄袭',
+    details: '规则描述高度相似',
+    status: 'pending',
+    createdAt: Date.parse('2026-06-10T15:00:00Z'),
+    updatedAt: Date.parse('2026-06-10T15:00:00Z'),
+    context: { targetLabel: '可疑规则' },
+  },
+]
+
+describe('审核后台 E2E', () => {
+  beforeEach(() => {
+    stubApiPreflight()
+    stubExternalImages()
+    cy.intercept('GET', /\/api\/admin\/rules\/pending$/, apiResponse({ success: true, data: pendingDrafts })).as('listPendingRules')
+    cy.intercept('POST', /\/api\/admin\/rules\/review-draft-1\/approve$/, apiResponse({
+      success: true,
+      data: { ruleId: 'published-rule-1', version: 1, status: 'published' },
+    })).as('approveRule')
+    cy.intercept('POST', /\/api\/admin\/rules\/review-draft-1\/reject$/, apiResponse({
+      success: true,
+      data: { id: 'review-draft-1', status: 'rejected', updatedAt: Date.now() },
+    })).as('rejectRule')
+
+    cy.intercept('GET', /\/api\/reports\/counts$/, apiResponse({ success: true, data: { pending: 2 } })).as('reportCounts')
+    cy.intercept('GET', /\/api\/reports(?:\?.*)?$/, apiResponse({ success: true, data: reports })).as('listReports')
+    cy.intercept('POST', /\/api\/reports\/report-1\/action$/, apiResponse({
+      success: true,
+      data: { ...reports[0], status: 'resolved' },
+    })).as('reportAction')
+  })
+
+  it('管理员可以预览待审规则 JSON 并批准发布', () => {
+    visitAs('/admin/rules-review', 'admin')
+    cy.wait('@listPendingRules')
+
+    cy.contains('h1', '规则审核').should('be.visible')
+    cy.contains('.pending-row', '待审 War 规则').click()
+    cy.contains('.detail-panel', '每轮比较牌面点数').should('be.visible')
+    cy.get('.detail-cover').should('have.attr', 'src').and('include', '/static/rule-images/review-cover.png')
+    cy.contains('button', '查看规则 JSON').click()
+    cy.get('.design-json').should('contain', 'start')
+
+    cy.contains('button', '批准发布').click()
+    cy.get('.el-message-box').contains('button', '批准').click()
+    cy.wait('@approveRule')
+    cy.contains('规则已批准发布').should('be.visible')
+  })
+
+  it('管理员驳回规则时提交必填原因', () => {
+    visitAs('/admin/rules-review', 'admin')
+    cy.wait('@listPendingRules')
+
+    cy.contains('.pending-row', '待审 War 规则').click()
+    cy.contains('button', '驳回').click()
+    cy.get('.el-message-box textarea').type('玩法说明不完整，请补充结算示例')
+    cy.get('.el-message-box').contains('button', '驳回').click()
+    cy.wait('@rejectRule').its('request.body').should('deep.eq', {
+      reason: '玩法说明不完整，请补充结算示例',
+    })
+    cy.contains('规则已驳回').should('be.visible')
+  })
+
+  it('管理员可以筛选举报并处理对局行为举报', () => {
+    visitAs('/admin/reports-review', 'admin')
+    cy.wait('@listReports')
+    cy.wait('@reportCounts')
+
+    cy.contains('h1', '举报审核').should('be.visible')
+    cy.contains('待处理 2').should('be.visible')
+    cy.contains('.report-list-item', 'BadPlayer 的对局行为').should('have.class', 'active')
+    cy.contains('.report-detail', '最后一轮长时间不操作').should('be.visible')
+
+    cy.get('input[placeholder="搜索目标、理由或说明"]').clear().type('拖延')
+    cy.contains('.filter-bar button', '筛选').click()
+    cy.wait('@listReports').its('request.url').should('include', 'keyword=%E6%8B%96%E5%BB%B6')
+
+    cy.contains('.detail-actions button', '封禁用户').click()
+    cy.get('.el-message-box textarea').type('已核实，封禁 24 小时')
+    cy.get('.el-message-box').contains('button', '确认').click()
+    cy.wait('@reportAction').its('request.body').should('deep.eq', {
+      action: 'ban_user',
+      note: '已核实，封禁 24 小时',
+      params: { targetType: 'player_behavior', targetId: 'room-42:bad-player' },
+    })
+    cy.contains('处理完成').should('be.visible')
+  })
+})

--- a/cypress/e2e/card-style.cy.ts
+++ b/cypress/e2e/card-style.cy.ts
@@ -1,0 +1,43 @@
+/// <reference types="cypress" />
+
+import { stubApiPreflight, stubExternalImages, visitAs } from './helpers'
+
+describe('卡牌样式设置 E2E', () => {
+  beforeEach(() => {
+    stubApiPreflight()
+    stubExternalImages()
+  })
+
+  it('保存、恢复并重置卡牌字体、主题和图片 URL', () => {
+    visitAs('/card-style')
+
+    cy.contains('h2', '卡牌样式设置').should('be.visible')
+    cy.contains('h2', '实时预览').should('be.visible')
+    cy.get('.front-card').should('have.class', 'theme-classic')
+
+    cy.contains('.setting-row', '字符字体').find('select').select("'Courier New', monospace")
+    cy.contains('.setting-row', '颜色风格').find('select').select('green')
+    cy.get('input[placeholder="留空则使用默认白色牌面"]').clear().type('https://example.test/front.png')
+    cy.get('input[placeholder="留空则使用默认卡通牌背"]').clear().type('https://example.test/back.png')
+
+    cy.get('.front-card').should('have.class', 'theme-green')
+    cy.window().then((win) => {
+      const saved = JSON.parse(win.localStorage.getItem('wildcard-card-style') || '{}')
+      expect(saved.fontFamily).to.eq("'Courier New', monospace")
+      expect(saved.theme).to.eq('green')
+      expect(saved.frontImage).to.eq('https://example.test/front.png')
+      expect(saved.backImage).to.eq('https://example.test/back.png')
+    })
+
+    cy.reload()
+    cy.contains('.setting-row', '字符字体').find('select').should('have.value', "'Courier New', monospace")
+    cy.contains('.setting-row', '颜色风格').find('select').should('have.value', 'green')
+    cy.get('input[placeholder="留空则使用默认白色牌面"]').should('have.value', 'https://example.test/front.png')
+    cy.get('input[placeholder="留空则使用默认卡通牌背"]').should('have.value', 'https://example.test/back.png')
+
+    cy.contains('button', '恢复默认').click()
+    cy.contains('.setting-row', '字符字体').find('select').should('have.value', 'Arial, sans-serif')
+    cy.contains('.setting-row', '颜色风格').find('select').should('have.value', 'classic')
+    cy.get('.front-card').should('have.class', 'theme-classic')
+  })
+})

--- a/cypress/e2e/creation-publish.cy.ts
+++ b/cypress/e2e/creation-publish.cy.ts
@@ -1,0 +1,118 @@
+/// <reference types="cypress" />
+
+import { apiResponse, stubApiPreflight, stubExternalImages, visitAs } from './helpers'
+
+const design = {
+  info: { name: 'War 改版', playerCount: 2, description: '拼点规则' },
+  classes: {},
+  cardsets: [],
+  cardsetComparisons: [],
+  matchFlow: { nodes: [], edges: [] },
+  endFlow: { nodes: [], edges: [] },
+  assets: { cardFaces: {}, cardBack: '', background: '' },
+}
+
+const drafts = [
+  {
+    id: 'draft-1',
+    name: 'War 改版',
+    playerCount: 2,
+    description: '拼点规则',
+    status: 'draft',
+    updatedAt: Date.parse('2026-06-10T10:00:00Z'),
+  },
+  {
+    id: 'draft-2',
+    name: '待审核规则',
+    playerCount: 4,
+    description: '已提交',
+    status: 'pendingReview',
+    updatedAt: Date.parse('2026-06-10T11:00:00Z'),
+  },
+  {
+    id: 'draft-3',
+    name: '被驳回规则',
+    playerCount: 3,
+    description: '需要补充资料',
+    status: 'rejected',
+    rejectReason: '请补充截图和玩法说明',
+    updatedAt: Date.parse('2026-06-10T12:00:00Z'),
+  },
+]
+
+const draftDetail = {
+  ...drafts[2],
+  createdAt: Date.parse('2026-06-09T12:00:00Z'),
+  introduction: '旧玩法介绍',
+  coverUrl: '/static/rule-images/cover.png',
+  screenshotUrls: ['/static/rule-images/shot-1.png'],
+  design,
+}
+
+describe('创作中心和规则发布 E2E', () => {
+  beforeEach(() => {
+    stubApiPreflight()
+    stubExternalImages()
+    cy.intercept('GET', /\/api\/rules\/drafts$/, apiResponse({ success: true, data: drafts })).as('listDrafts')
+    cy.intercept('GET', /\/api\/rules\/drafts\/draft-3$/, apiResponse({ success: true, data: draftDetail })).as('getDraft')
+    cy.intercept('PUT', /\/api\/rules\/drafts\/draft-3$/, apiResponse({ success: true, data: { id: 'draft-3', updatedAt: Date.now() } })).as('updateDraft')
+    cy.intercept('POST', /\/api\/rules\/drafts\/draft-3\/submit-review$/, apiResponse({
+      success: true,
+      data: { id: 'draft-3', status: 'pendingReview', updatedAt: Date.now() },
+    })).as('submitReview')
+    cy.intercept('DELETE', /\/api\/rules\/drafts\/draft-1$/, apiResponse({ success: true, data: drafts[0] })).as('deleteDraft')
+  })
+
+  it('展示草稿状态、驳回原因，并从驳回规则重新提交审核', () => {
+    visitAs('/creation-center')
+    cy.wait('@listDrafts')
+
+    cy.contains('h1', '创作中心').should('be.visible')
+    cy.contains('.rule-row', 'War 改版').within(() => {
+      cy.contains('.status-pill', '草稿').should('have.class', 'draft')
+      cy.contains('button', '发布规则').should('be.enabled')
+    })
+    cy.contains('.rule-row', '待审核规则').within(() => {
+      cy.contains('.status-pill', '审核中').should('have.class', 'pendingReview')
+      cy.contains('button', '审核中').should('be.disabled')
+    })
+    cy.contains('.rule-row', '被驳回规则').within(() => {
+      cy.contains('.status-pill', '已驳回').should('have.class', 'rejected')
+      cy.contains('驳回原因：请补充截图和玩法说明').should('be.visible')
+      cy.contains('button', '重新发布').click()
+    })
+
+    cy.location('pathname').should('eq', '/creation-center/draft-3/publish')
+    cy.wait('@getDraft')
+    cy.contains('h1', '发布规则').should('be.visible')
+    cy.contains('.reject-banner', '请补充截图和玩法说明').should('be.visible')
+    cy.get('.cover-preview img').should('have.attr', 'src').and('include', '/static/rule-images/cover.png')
+    cy.get('.shot-item').should('have.length', 1)
+
+    cy.get('textarea').clear().type('补充后的玩法介绍\n包含胜负判定和截图说明')
+    cy.contains('button', '保存草稿').click()
+    cy.wait('@updateDraft').its('request.body').should((body) => {
+      expect(body.introduction).to.include('补充后的玩法介绍')
+      expect(body.coverUrl).to.eq('/static/rule-images/cover.png')
+      expect(body.screenshotUrls).to.deep.eq(['/static/rule-images/shot-1.png'])
+      expect(body.design).to.deep.eq(design)
+    })
+
+    cy.contains('button', '重新提交审核').click()
+    cy.wait('@updateDraft')
+    cy.wait('@submitReview')
+    cy.contains('button', '审核中').should('be.disabled')
+  })
+
+  it('支持从创作中心删除单个草稿并刷新列表状态', () => {
+    visitAs('/creation-center')
+    cy.wait('@listDrafts')
+
+    cy.contains('.rule-row', 'War 改版').within(() => {
+      cy.contains('button', '删除').click()
+    })
+    cy.get('.el-message-box').contains('button', '删除').click()
+    cy.wait('@deleteDraft')
+    cy.contains('.rule-row', 'War 改版').should('not.exist')
+  })
+})

--- a/cypress/e2e/helpers.ts
+++ b/cypress/e2e/helpers.ts
@@ -1,0 +1,129 @@
+/// <reference types="cypress" />
+
+type TestRole = 'user' | 'admin'
+
+export const testUser = {
+  id: 'player-1',
+  username: '测试玩家',
+  email: 'player@example.com',
+  avatar: '',
+  role: 'user',
+  token: 'test-token-user',
+}
+
+export const adminUser = {
+  ...testUser,
+  id: 'admin-1',
+  username: '审核员',
+  email: 'admin@example.com',
+  role: 'admin',
+  token: 'test-token-admin',
+}
+
+export function corsHeaders(origin?: string | string[]) {
+  const requestOrigin = Array.isArray(origin) ? origin[0] : origin
+  return {
+    'access-control-allow-origin': requestOrigin || '*',
+    'access-control-allow-credentials': 'true',
+    'access-control-allow-methods': 'GET,POST,PUT,DELETE,OPTIONS',
+    'access-control-allow-headers': 'content-type,authorization,x-player-id,x-player-name,x-player-avatar,x-room-code',
+  }
+}
+
+export function apiResponse<T>(body: T) {
+  return (req: Cypress.Request) => {
+    req.reply({
+      headers: corsHeaders(req.headers.origin),
+      body,
+    })
+  }
+}
+
+export function stubApiPreflight() {
+  cy.intercept('OPTIONS', /\/api\/.*$/, (req) => {
+    req.reply({
+      statusCode: 204,
+      headers: corsHeaders(req.headers.origin),
+    })
+  })
+}
+
+export function stubExternalImages() {
+  cy.intercept('https://www.gravatar.com/**', {
+    statusCode: 200,
+    body: '',
+    headers: { 'Content-Type': 'image/png' },
+  })
+}
+
+export function visitAs(path: string, role: TestRole = 'user') {
+  const user = role === 'admin' ? adminUser : testUser
+  cy.intercept('GET', /\/api\/user\/current$/, apiResponse({ success: true, data: user })).as('getCurrentUser')
+  cy.visit('/user-info', {
+    timeout: 60000,
+    onBeforeLoad(win) {
+      win.sessionStorage.setItem('wildcard:default:user', JSON.stringify(user))
+      win.sessionStorage.setItem('wildcard:default:auth-token', user.token)
+    },
+  })
+  cy.wait('@getCurrentUser')
+
+  if (path !== '/user-info') {
+    cy.visit(path, {
+      timeout: 60000,
+    })
+    cy.location('pathname').should('eq', path)
+  }
+}
+
+export function stubRoomApis() {
+  const rule = {
+    id: 'classic',
+    name: 'Classic Demo',
+    playerCount: 2,
+    description: 'Stable room rule for E2E tests.',
+  }
+  const hostRoom = {
+    id: 'room-host',
+    code: 'ABC123',
+    hostId: testUser.id,
+    playerCount: 2,
+    roundTime: 30,
+    ruleId: rule.id,
+    ruleName: rule.name,
+    password: null,
+    hasPassword: false,
+    players: [
+      { id: testUser.id, username: testUser.username, avatar: '', isReady: true, joinedAt: 1 },
+    ],
+    status: 'waiting',
+  }
+  const guestRoom = {
+    ...hostRoom,
+    id: 'room-guest',
+    code: '123456',
+    hostId: 'host-player',
+    password: 'abc123',
+    hasPassword: true,
+    players: [
+      { id: 'host-player', username: '房主A', avatar: '', isReady: true, joinedAt: 1 },
+      { id: testUser.id, username: testUser.username, avatar: '', isReady: false, joinedAt: 2 },
+    ],
+  }
+  let currentRoom = hostRoom
+
+  cy.intercept('GET', /\/api\/room\/rules$/, apiResponse({ success: true, data: [rule] })).as('roomRules')
+  cy.intercept('POST', /\/api\/room\/create$/, (req) => {
+    currentRoom = { ...hostRoom, roundTime: Number(req.body?.roundTime || 30) }
+    req.reply({ headers: corsHeaders(req.headers.origin), body: { success: true, data: currentRoom } })
+  }).as('createRoom')
+  cy.intercept('GET', /\/api\/room\/check-password(?:\?.*)?$/, apiResponse({ success: true, hasPassword: true })).as('checkPassword')
+  cy.intercept('POST', /\/api\/room\/join$/, (req) => {
+    currentRoom = guestRoom
+    req.reply({ headers: corsHeaders(req.headers.origin), body: { success: true, data: guestRoom } })
+  }).as('joinRoom')
+  cy.intercept('GET', /\/api\/room\/current(?:\?.*)?$/, (req) => {
+    req.reply({ headers: corsHeaders(req.headers.origin), body: { success: true, data: currentRoom } })
+  }).as('currentRoom')
+  cy.intercept('POST', /\/api\/room\/leave$/, apiResponse({ success: true })).as('leaveRoom')
+}

--- a/cypress/e2e/match-replay.cy.ts
+++ b/cypress/e2e/match-replay.cy.ts
@@ -1,0 +1,83 @@
+/// <reference types="cypress" />
+
+import { apiResponse, stubApiPreflight, stubExternalImages, visitAs } from './helpers'
+
+const cardA = { id: 'a-heart', properties: { point: 1, suit: 1 }, display: { rank: 'A', suit: 'H' } }
+const cardK = { id: 'k-spade', properties: { point: 13, suit: 0 }, display: { rank: 'K', suit: 'S' } }
+
+const record = {
+  id: 'replay-1',
+  sessionId: 'session-1',
+  roomCode: 'ROOM42',
+  ruleId: 'war-rule',
+  ruleName: 'War 拼点战争',
+  startedAt: '2026-06-10T10:00:00.000Z',
+  endedAt: '2026-06-10T10:05:00.000Z',
+  result: 'win',
+  players: [
+    { id: 'player-1', username: '测试玩家', avatar: '' },
+    { id: 'player-2', username: '对手', avatar: '' },
+  ],
+  winnerIds: ['player-1'],
+}
+
+const replay = {
+  record,
+  frames: [
+    {
+      index: 0,
+      elapsedSeconds: 0,
+      currentPlayerId: 'player-1',
+      hands: { 'player-1': [cardA, cardK], 'player-2': [cardK] },
+      tableCards: [],
+      action: null,
+    },
+    {
+      index: 1,
+      elapsedSeconds: 22,
+      currentPlayerId: 'player-2',
+      hands: { 'player-1': [cardK], 'player-2': [cardK] },
+      tableCards: [cardA],
+      action: { playerId: 'player-1', action: 'playCards', cards: [cardA], message: '测试玩家打出了 A H', turn: 1 },
+    },
+  ],
+}
+
+describe('历史对局和回放 E2E', () => {
+  beforeEach(() => {
+    stubApiPreflight()
+    stubExternalImages()
+    cy.intercept('GET', /\/api\/replays\/history(?:\?.*)?$/, apiResponse({ success: true, data: [record] })).as('history')
+    cy.intercept('GET', /\/api\/replays\/replay-1$/, apiResponse({ success: true, data: replay })).as('replay')
+  })
+
+  it('从历史对局进入回放并步进时间线', () => {
+    visitAs('/match-history')
+    cy.wait('@history')
+
+    cy.contains('h1', '历史对局').should('be.visible')
+    cy.contains('.history-card', 'War 拼点战争').within(() => {
+      cy.contains('.result-mark', '胜').should('have.class', 'win')
+      cy.contains('房间 ROOM42').should('be.visible')
+      cy.contains('测试玩家、对手').should('be.visible')
+      cy.contains('button', '查看回放').click()
+    })
+
+    cy.location('pathname').should('eq', '/match-history/replay-1')
+    cy.wait('@replay')
+    cy.contains('h1', 'War 拼点战争').should('be.visible')
+    cy.contains('.summary-bar', 'ROOM42').should('be.visible')
+    cy.contains('.summary-bar', '1/2').should('be.visible')
+    cy.contains('.player-panel.active', '测试玩家').should('be.visible')
+    cy.contains('.table-empty', '桌面暂无出牌').should('be.visible')
+
+    cy.contains('button', '下一步').click()
+    cy.contains('.summary-bar', '2/2').should('be.visible')
+    cy.contains('.player-panel.active', '对手').should('be.visible')
+    cy.contains('.table-card', 'A').should('be.visible')
+    cy.contains('.action-text', '测试玩家打出了 A H').should('be.visible')
+
+    cy.get('button[title="返回历史对局"]').click()
+    cy.location('pathname').should('eq', '/match-history')
+  })
+})

--- a/cypress/e2e/ready-room.cy.ts
+++ b/cypress/e2e/ready-room.cy.ts
@@ -1,5 +1,7 @@
 /// <reference types="cypress" />
 
+import { stubRoomApis, visitAs } from './helpers'
+
 describe('ReadyRoomView 房间准备页面测试', () => {
   // 房间信息显示测试组
   describe('房间信息显示', () => {
@@ -9,14 +11,16 @@ describe('ReadyRoomView 房间准备页面测试', () => {
       cy.clearLocalStorage()
       
       // 创建房间
-      cy.visit('/create-room', { timeout: 60000 })
-      cy.contains('h1', 'Create Room', { timeout: 10000 }).should('be.visible')
-      cy.contains('Room Settings', { timeout: 10000 }).should('be.visible')
-      cy.contains('Classic Rules (4 players)', { timeout: 10000 }).should('be.visible')
-      cy.contains('button', 'Create Room').should('be.enabled').click()
+      stubRoomApis()
+      visitAs('/create-room')
+      cy.contains('h1', '创建房间', { timeout: 10000 }).should('be.visible')
+      cy.contains('房间设置', { timeout: 10000 }).should('be.visible')
+      cy.contains('Classic Demo（2人）', { timeout: 10000 }).should('be.visible')
+      cy.contains('button', '创建房间').should('be.enabled').click()
+      cy.wait('@createRoom')
       
       // 等待跳转和页面加载
-      cy.location('pathname', { timeout: 15000 }).should('match', /^\/game\/[A-Z0-9]{6}$/)
+      cy.location('pathname', { timeout: 15000 }).should('eq', '/game/ABC123')
       cy.get('.room-eyebrow', { timeout: 10000 }).should('contain', 'Ready Room')
       cy.get('.room-summary', { timeout: 10000 }).should('be.visible')
       cy.get('.players-grid', { timeout: 10000 }).should('be.visible')
@@ -32,7 +36,7 @@ describe('ReadyRoomView 房间准备页面测试', () => {
     })
 
     it('显示房间号和规则名称', () => {
-      cy.get('.summary-value').contains('Classic Rules')
+      cy.get('.summary-value').contains('Classic Demo')
     })
   })
 
@@ -44,14 +48,16 @@ describe('ReadyRoomView 房间准备页面测试', () => {
       cy.clearLocalStorage()
       
       // 创建房间
-      cy.visit('/create-room', { timeout: 60000 })
-      cy.contains('h1', 'Create Room', { timeout: 10000 }).should('be.visible')
-      cy.contains('Room Settings', { timeout: 10000 }).should('be.visible')
-      cy.contains('Classic Rules (4 players)', { timeout: 10000 }).should('be.visible')
-      cy.contains('button', 'Create Room').should('be.visible').click()
+      stubRoomApis()
+      visitAs('/create-room')
+      cy.contains('h1', '创建房间', { timeout: 10000 }).should('be.visible')
+      cy.contains('房间设置', { timeout: 10000 }).should('be.visible')
+      cy.contains('Classic Demo（2人）', { timeout: 10000 }).should('be.visible')
+      cy.contains('button', '创建房间').should('be.visible').click()
+      cy.wait('@createRoom')
       
       // 等待跳转和页面加载
-      cy.location('pathname', { timeout: 15000 }).should('match', /^\/game\/[A-Z0-9]{6}$/)
+      cy.location('pathname', { timeout: 15000 }).should('eq', '/game/ABC123')
       cy.get('.room-eyebrow', { timeout: 10000 }).should('contain', 'Ready Room')
       cy.get('.room-summary', { timeout: 10000 }).should('be.visible')
       cy.get('.players-grid', { timeout: 10000 }).should('be.visible')
@@ -79,14 +85,16 @@ describe('ReadyRoomView 房间准备页面测试', () => {
       cy.clearLocalStorage()
       
       // 创建房间
-      cy.visit('/create-room', { timeout: 60000 })
-      cy.contains('h1', 'Create Room', { timeout: 10000 }).should('be.visible')
-      cy.contains('Room Settings', { timeout: 10000 }).should('be.visible')
-      cy.contains('Classic Rules (4 players)', { timeout: 10000 }).should('be.visible')
-      cy.contains('button', 'Create Room').should('be.visible').click()
+      stubRoomApis()
+      visitAs('/create-room')
+      cy.contains('h1', '创建房间', { timeout: 10000 }).should('be.visible')
+      cy.contains('房间设置', { timeout: 10000 }).should('be.visible')
+      cy.contains('Classic Demo（2人）', { timeout: 10000 }).should('be.visible')
+      cy.contains('button', '创建房间').should('be.visible').click()
+      cy.wait('@createRoom')
       
       // 等待跳转和页面加载
-      cy.location('pathname', { timeout: 15000 }).should('match', /^\/game\/[A-Z0-9]{6}$/)
+      cy.location('pathname', { timeout: 15000 }).should('eq', '/game/ABC123')
       cy.get('.room-eyebrow', { timeout: 10000 }).should('contain', 'Ready Room')
       cy.get('.room-summary', { timeout: 10000 }).should('be.visible')
       cy.get('.players-grid', { timeout: 10000 }).should('be.visible')
@@ -111,12 +119,15 @@ describe('ReadyRoomView 房间准备页面测试', () => {
       
       // 注意：这里需要先创建一个房间，然后用另一个用户加入
       // 简化处理：直接加入一个已存在的测试房间
-      cy.visit('/join-room', { timeout: 60000 })
+      stubRoomApis()
+      visitAs('/join-room')
       cy.get('.join-room-input input', { timeout: 10000 }).should('be.visible').type('123456')
       cy.contains('button', '加入房间').should('be.enabled').click()
+      cy.wait('@checkPassword')
       cy.contains('密码', { timeout: 10000 }).should('be.visible')
       cy.get('.join-room-input input').type('abc123')
       cy.contains('button', '加入房间').should('be.enabled').click()
+      cy.wait('@joinRoom')
       
       // 等待跳转和页面加载
       cy.location('pathname', { timeout: 15000 }).should('eq', '/game/123456')
@@ -139,14 +150,16 @@ describe('ReadyRoomView 房间准备页面测试', () => {
       cy.clearLocalStorage()
       
       // 创建房间
-      cy.visit('/create-room', { timeout: 60000 })
-      cy.contains('h1', 'Create Room', { timeout: 10000 }).should('be.visible')
-      cy.contains('Room Settings', { timeout: 10000 }).should('be.visible')
-      cy.contains('Classic Rules (4 players)', { timeout: 10000 }).should('be.visible')
-      cy.contains('button', 'Create Room').should('be.visible').click()
+      stubRoomApis()
+      visitAs('/create-room')
+      cy.contains('h1', '创建房间', { timeout: 10000 }).should('be.visible')
+      cy.contains('房间设置', { timeout: 10000 }).should('be.visible')
+      cy.contains('Classic Demo（2人）', { timeout: 10000 }).should('be.visible')
+      cy.contains('button', '创建房间').should('be.visible').click()
+      cy.wait('@createRoom')
       
       // 等待跳转和页面加载
-      cy.location('pathname', { timeout: 15000 }).should('match', /^\/game\/[A-Z0-9]{6}$/)
+      cy.location('pathname', { timeout: 15000 }).should('eq', '/game/ABC123')
       cy.get('.room-eyebrow', { timeout: 10000 }).should('contain', 'Ready Room')
       cy.get('.room-summary', { timeout: 10000 }).should('be.visible')
       cy.get('.players-grid', { timeout: 10000 }).should('be.visible')

--- a/cypress/e2e/room.cy.ts
+++ b/cypress/e2e/room.cy.ts
@@ -1,30 +1,37 @@
 /// <reference types="cypress" />
 
+import { stubRoomApis, visitAs } from './helpers'
+
 describe('online room pages', () => {
   it('creates a room and navigates to the game page', () => {
-    cy.visit('/create-room', { timeout: 60000 })
+    stubRoomApis()
+    visitAs('/create-room')
 
-    cy.contains('h1', 'Create Room').should('be.visible')
-    cy.contains('Room Settings').should('be.visible')
-    cy.contains('Classic Rules (4 players)').should('be.visible')
-    cy.contains('button', 'Create Room').click()
+    cy.contains('h1', '创建房间').should('be.visible')
+    cy.contains('房间设置').should('be.visible')
+    cy.contains('Classic Demo（2人）').should('be.visible')
+    cy.contains('button', '创建房间').click()
+    cy.wait('@createRoom')
 
-    cy.location('pathname').should('match', /^\/game\/[A-Z0-9]{6}$/)
+    cy.location('pathname').should('eq', '/game/ABC123')
     cy.window().then((win) => {
-      expect(win.sessionStorage.getItem('currentRoomCode')).to.match(/^[A-Z0-9]{6}$/)
+      expect(win.sessionStorage.getItem('currentRoomCode')).to.eq('ABC123')
     })
   })
 
   it('joins a password-protected room and navigates to the game page', () => {
-    cy.visit('/join-room', { timeout: 60000 })
+    stubRoomApis()
+    visitAs('/join-room')
 
-    cy.contains('h1', 'Join Room').should('be.visible')
+    cy.contains('h1', '加入房间').should('be.visible')
     cy.get('.join-room-input input').type('123456')
     cy.contains('button', '加入房间').click()
+    cy.wait('@checkPassword')
 
     cy.contains('密码').should('be.visible')
     cy.get('.join-room-input input').type('abc123')
     cy.contains('button', '加入房间').click()
+    cy.wait('@joinRoom')
 
     cy.location('pathname').should('eq', '/game/123456')
     cy.window().then((win) => {

--- a/cypress/e2e/rule-builder.cy.ts
+++ b/cypress/e2e/rule-builder.cy.ts
@@ -1,8 +1,10 @@
 /// <reference types="cypress" />
 
+import { visitAs } from './helpers'
+
 describe('规则构建器测试', () => {
   beforeEach(() => {
-    cy.visit('/creation-center', { timeout: 60000 })
+    visitAs('/creation-center/new')
     cy.intercept('https://www.gravatar.com/**', { statusCode: 200, body: '', headers: { 'Content-Type': 'image/png' } })
   })
 
@@ -57,9 +59,9 @@ describe('规则构建器测试', () => {
     })
 
     it('显示对象摘要', () => {
-      cy.contains('.object-summary', '玩家对象').should('be.visible')
-      cy.contains('.object-summary', '牌对象').should('be.visible')
-      cy.contains('.object-summary', '牌桌对象').should('be.visible')
+      cy.contains('.object-summary', '玩家对象').scrollIntoView().should('be.visible')
+      cy.contains('.object-summary', '牌对象').scrollIntoView().should('be.visible')
+      cy.contains('.object-summary', '牌桌对象').scrollIntoView().should('be.visible')
     })
   })
 

--- a/cypress/e2e/user-auth.cy.ts
+++ b/cypress/e2e/user-auth.cy.ts
@@ -1,10 +1,23 @@
 /// <reference types="cypress" />
 
+import { apiResponse, testUser, visitAs } from './helpers'
+
+const loginUser = {
+  ...testUser,
+  id: '1',
+  username: 'testuser',
+  email: 'test@mail.com',
+  token: 'test-token-login',
+}
+
 describe('用户认证测试', () => {
   beforeEach(() => {
     cy.clearCookies()
     cy.clearLocalStorage()
     cy.intercept('https://www.gravatar.com/**', { statusCode: 200, body: '', headers: { 'Content-Type': 'image/png' } })
+    cy.intercept('GET', /\/api\/user\/current$/, apiResponse({ success: false, message: '未登录' })).as('getCurrentUser')
+    cy.intercept('POST', /\/api\/user\/login$/, apiResponse({ success: true, data: loginUser })).as('login')
+    cy.intercept('POST', /\/api\/user\/send-code$/, apiResponse({ success: true, message: '验证码已发送，请检查邮箱' })).as('sendCode')
     cy.visit('/user-info', { timeout: 60000 })
   })
 
@@ -31,9 +44,10 @@ describe('用户认证测试', () => {
 
   describe('Mock模式登录功能', () => {
     it('使用mock账户登录成功', () => {
-      cy.get('input[placeholder="example@mail.com"]').first().clear().type('test@mail.com')
-      cy.get('input[type="password"]').first().clear().type('password123')
+      cy.get('input[placeholder="邮箱或用户名"]:visible').clear().type('test@mail.com')
+      cy.get('input[type="password"]:visible').clear().type('password123')
       cy.contains('button', '登录').click()
+      cy.wait('@login')
       cy.contains('testuser', { timeout: 10000 }).should('be.visible')
     })
   })
@@ -52,18 +66,21 @@ describe('用户认证测试', () => {
 
     it('可以发送验证码到有效邮箱', () => {
       cy.contains('注册').click()
-      cy.get('input[placeholder="example@mail.com"]').last().clear().type('newuser@mail.com')
+      cy.get('input[placeholder="example@mail.com"]:visible').clear().type('newuser@mail.com')
       cy.contains('发送验证码').click()
+      cy.wait('@sendCode')
       cy.contains('验证码已发送', { timeout: 5000 }).should('be.visible')
     })
   })
 
   describe('导航功能', () => {
     it('侧边栏显示用户中心链接', () => {
+      visitAs('/user-info')
       cy.get('.sidebar').contains('用户中心').should('be.visible')
     })
 
     it('点击用户中心链接跳转到用户页面', () => {
+      visitAs('/')
       cy.contains('用户中心').click()
       cy.url().should('include', '/user-info')
     })

--- a/cypress/e2e/user-profile.cy.ts
+++ b/cypress/e2e/user-profile.cy.ts
@@ -1,7 +1,32 @@
 /// <reference types="cypress" />
 
+import { apiResponse, testUser, visitAs } from './helpers'
+
+const loginUser = {
+  ...testUser,
+  id: '1',
+  username: 'testuser',
+  email: 'test@mail.com',
+  token: 'test-token-login',
+}
+
+function stubLoggedOutApis() {
+  cy.intercept('GET', /\/api\/user\/current$/, apiResponse({ success: false, message: '未登录' })).as('getCurrentUser')
+  cy.intercept('POST', /\/api\/user\/login$/, apiResponse({ success: true, data: loginUser })).as('login')
+  cy.intercept('POST', /\/api\/user\/logout$/, apiResponse({ success: true })).as('logout')
+}
+
+function loginThroughForm() {
+  cy.get('input[placeholder="邮箱或用户名"]:visible').clear().type('test@mail.com')
+  cy.get('input[type="password"]:visible').clear().type('password123')
+  cy.contains('button', '登录').click()
+  cy.wait('@login')
+  cy.contains('testuser', { timeout: 10000 }).should('be.visible')
+}
+
 describe('用户信息管理测试', () => {
   beforeEach(() => {
+    stubLoggedOutApis()
     cy.visit('/user-info', { timeout: 60000 })
     cy.intercept('https://www.gravatar.com/**', { statusCode: 200, body: '', headers: { 'Content-Type': 'image/png' } })
   })
@@ -20,10 +45,7 @@ describe('用户信息管理测试', () => {
 
   describe('已登录用户功能', () => {
     beforeEach(() => {
-      cy.get('input[placeholder="example@mail.com"]').first().clear().type('test@mail.com')
-      cy.get('input[type="password"]').first().clear().type('password123')
-      cy.contains('button', '登录').click()
-      cy.contains('testuser', { timeout: 10000 }).should('be.visible')
+      loginThroughForm()
     })
 
     it('显示用户头像', () => {
@@ -35,20 +57,18 @@ describe('用户信息管理测试', () => {
     })
 
     it('显示退出登录按钮', () => {
-      cy.contains('退出登录').should('be.visible')
+      cy.contains('退出登录').scrollIntoView().should('be.visible')
     })
   })
 
   describe('退出登录功能', () => {
     beforeEach(() => {
-      cy.get('input[placeholder="example@mail.com"]').first().clear().type('test@mail.com')
-      cy.get('input[type="password"]').first().clear().type('password123')
-      cy.contains('button', '登录').click()
-      cy.contains('testuser', { timeout: 10000 }).should('be.visible')
+      loginThroughForm()
     })
 
     it('点击退出登录返回到登录表单', () => {
       cy.contains('退出登录').click()
+      cy.wait('@logout')
       cy.contains('登录').should('be.visible')
       cy.contains('注册').should('be.visible')
     })
@@ -56,41 +76,39 @@ describe('用户信息管理测试', () => {
 
   describe('首页入口测试', () => {
     it('首页显示CREATE ROOM按钮', () => {
-      cy.visit('/', { timeout: 60000 })
-      cy.contains('button', 'CREATE ROOM').should('be.visible')
+      visitAs('/')
+      cy.contains('button', '创建房间').should('be.visible')
     })
 
     it('首页显示JOIN ROOM按钮', () => {
-      cy.visit('/', { timeout: 60000 })
-      cy.contains('button', 'JOIN ROOM').should('be.visible')
+      visitAs('/')
+      cy.contains('button', '加入房间').should('be.visible')
     })
 
     it('点击CREATE ROOM跳转到创建房间页面', () => {
-      cy.visit('/', { timeout: 60000 })
-      cy.contains('button', 'CREATE ROOM').click()
+      visitAs('/')
+      cy.contains('button', '创建房间').click()
       cy.url().should('include', '/create-room')
     })
   })
 
   describe('侧边栏用户展示同步', () => {
-    it('未登录时侧边栏显示未登录', () => {
-      cy.get('.sidebar').contains('未登录').should('be.visible')
+    it('未登录时显示登录表单', () => {
+      cy.contains('登录').should('be.visible')
+      cy.contains('注册').should('be.visible')
     })
 
     it('登录后侧边栏显示用户信息', () => {
-      cy.get('input[placeholder="example@mail.com"]').first().clear().type('test@mail.com')
-      cy.get('input[type="password"]').first().clear().type('password123')
-      cy.contains('button', '登录').click()
+      loginThroughForm()
       cy.get('.sidebar').contains('testuser', { timeout: 10000 }).should('be.visible')
     })
 
-    it('退出登录后侧边栏恢复默认显示', () => {
-      cy.get('input[placeholder="example@mail.com"]').first().clear().type('test@mail.com')
-      cy.get('input[type="password"]').first().clear().type('password123')
-      cy.contains('button', '登录').click()
-      cy.contains('testuser', { timeout: 10000 }).should('be.visible')
+    it('退出登录后返回登录表单', () => {
+      loginThroughForm()
       cy.contains('退出登录').click()
-      cy.get('.sidebar').contains('未登录').should('be.visible')
+      cy.wait('@logout')
+      cy.contains('登录').should('be.visible')
+      cy.contains('注册').should('be.visible')
     })
   })
 })

--- a/cypress/e2e/user.cy.ts
+++ b/cypress/e2e/user.cy.ts
@@ -1,12 +1,14 @@
 /// <reference types="cypress" />
 
+import { visitAs } from './helpers'
+
 describe('user shell', () => {
   it('renders the application shell and home entry actions', () => {
-    cy.visit('/', { timeout: 60000 })
+    visitAs('/')
 
     cy.get('[data-testid="app-shell"]').should('exist')
     cy.contains('WildCard').should('be.visible')
-    cy.contains('button', 'CREATE ROOM').should('be.visible')
-    cy.contains('button', 'JOIN ROOM').should('be.visible')
+    cy.contains('button', '创建房间').should('be.visible')
+    cy.contains('button', '加入房间').should('be.visible')
   })
 })

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -5,6 +5,7 @@ Cypress.on('uncaught:exception', () => false)
 beforeEach(() => {
   cy.clearCookies()
   cy.clearLocalStorage()
+  cy.clearAllSessionStorage()
   cy.intercept('https://www.gravatar.com/**', {
     statusCode: 200,
     body: '',
@@ -15,4 +16,5 @@ beforeEach(() => {
 afterEach(() => {
   cy.clearCookies()
   cy.clearLocalStorage()
+  cy.clearAllSessionStorage()
 })

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:unit": "vitest run",
     "test:unit:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:e2e": "start-server-and-test \"VITE_ENABLE_TEST_SANDBOX=true npm run build && vite preview --host 127.0.0.1 --port 4173\" http://127.0.0.1:4173 \"cypress run --browser electron\"",
+    "test:e2e": "start-server-and-test \"VITE_ENABLE_TEST_SANDBOX=true npm run build && vite preview --host 127.0.0.1 --port 4173 --strictPort\" http://127.0.0.1:4173 \"cypress run --browser electron\"",
     "test:e2e:open": "cypress open"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- re-enable Cypress installation, cache checks, and E2E execution in the frontend CI workflow
- add shared Cypress helpers for authenticated visits, CORS preflight stubs, image stubs, and room API fixtures
- add E2E coverage for admin review/report handling, card style persistence, creation center publish/delete flows, and match replay navigation
- update existing E2E specs to match current Chinese UI text and isolated session storage behavior

## Related Issues
- relates #133
- relates #132
- relates #131
- relates #115
- relates #113

## Verification
- CYPRESS_BASE_URL=http://127.0.0.1:4174 npx cypress run --browser electron: 11 specs, 57 tests passed
- npm run test:unit: 34 files, 191 tests passed
- npm run build: passed

Note: local port 4173 is occupied by an unrelated python http.server in this workspace, so I verified the Cypress suite against a strict Vite preview on 4174. CI will use the package script on a clean runner with --strictPort to avoid false positives against a stale service.