### PR TITLE
test: cover rule market media and admin preview e2e

### DIFF
--- a/cypress/e2e/admin-review.cy.ts
+++ b/cypress/e2e/admin-review.cy.ts
@@ -53,6 +53,22 @@ describe('审核后台 E2E', () => {
     stubApiPreflight()
     stubExternalImages()
     cy.intercept('GET', /\/api\/admin\/rules\/pending$/, apiResponse({ success: true, data: pendingDrafts })).as('listPendingRules')
+    cy.intercept('GET', /\/api\/admin\/rules\/drafts\/review-draft-1$/, apiResponse({
+      success: true,
+      data: {
+        id: 'review-draft-1',
+        name: '待审 War 规则',
+        playerCount: 2,
+        description: '需要审核的拼点规则',
+        status: 'pendingReview',
+        updatedAt: Date.parse('2026-06-10T13:00:00Z'),
+        createdAt: Date.parse('2026-06-10T12:30:00Z'),
+        design: { nodes: [{ id: 'start' }], edges: [] },
+        introduction: '每轮比较牌面点数。',
+        coverUrl: '/static/rule-images/review-cover.png',
+        screenshotUrls: ['/static/rule-images/review-shot.png'],
+      },
+    })).as('getPreviewDraft')
     cy.intercept('POST', /\/api\/admin\/rules\/review-draft-1\/approve$/, apiResponse({
       success: true,
       data: { ruleId: 'published-rule-1', version: 1, status: 'published' },
@@ -99,6 +115,22 @@ describe('审核后台 E2E', () => {
       reason: '玩法说明不完整，请补充结算示例',
     })
     cy.contains('规则已驳回').should('be.visible')
+  })
+
+  it('管理员可以进入规则可视化只读预览', () => {
+    visitAs('/admin/rules-review', 'admin')
+    cy.wait('@listPendingRules')
+
+    cy.contains('.pending-row', '待审 War 规则').click()
+    cy.contains('button', '可视化预览').click()
+
+    cy.wait('@getPreviewDraft')
+    cy.location('pathname').should('eq', '/admin/rules-review/preview/review-draft-1')
+    cy.get('.rule-builder-page').should('have.class', 'readonly-mode')
+    cy.contains('.readonly-banner', '只读预览模式').should('be.visible')
+    cy.contains('button', '保存草稿').should('not.exist')
+    cy.contains('button', '提交审核').should('not.exist')
+    cy.contains('button', '导入 JSON').should('not.exist')
   })
 
   it('管理员可以筛选举报并处理对局行为举报', () => {

--- a/cypress/e2e/rule-market.cy.ts
+++ b/cypress/e2e/rule-market.cy.ts
@@ -96,6 +96,10 @@ describe('规则市场', () => {
     cy.intercept('GET', /\/api\/rules\/published\/[^/]+\/rooms$/, apiResponse({ success: true, data: rooms })).as('listRuleRooms')
     cy.intercept('GET', /\/api\/rules\/developers\/system\/rules(?:\?.*)?$/, apiResponse({ success: true, data: [rules[0]] })).as('listDeveloperRules')
     cy.intercept('GET', /\/api\/rules\/published\/builtin-war-rule$/, apiResponse({ success: true, data: detail })).as('getRuleDetail')
+    cy.intercept('POST', /\/api\/rules\/reviews\/images$/, apiResponse({
+      success: true,
+      data: { imageUrl: '/static/review-images/review-uploaded.png' },
+    })).as('uploadReviewImage')
     cy.intercept('POST', /\/api\/rules\/published\/builtin-war-rule\/reviews$/, apiResponse({
       success: true,
       data: {
@@ -153,6 +157,54 @@ describe('规则市场', () => {
       name: 'War 战争副本',
     })
     cy.location('pathname').should('eq', '/creation-center/forked-war-rule')
+  })
+
+  it('详情页会解析短链接封面，并在提交带图评论前先上传评论图片', () => {
+    cy.intercept('GET', /\/api\/rules\/published\/builtin-war-rule$/, apiResponse({
+      success: true,
+      data: {
+        ...detail,
+        coverUrl: '/static/rule-images/cover.png',
+        screenshots: ['/static/rule-images/shot.png'],
+      },
+    })).as('getRuleDetailWithMedia')
+    cy.intercept('POST', /\/api\/rules\/published\/builtin-war-rule\/reviews$/, apiResponse({
+      success: true,
+      data: {
+        id: 'review-2',
+        authorName: '我',
+        authorAvatar: '/me.png',
+        rating: 5,
+        content: '带图评论',
+        imageUrl: '/static/review-images/review-uploaded.png',
+        createdAt: Date.parse('2026-05-30T00:00:00Z'),
+      },
+    })).as('postReviewWithImage')
+
+    visitAsLoggedIn('/rule-market/builtin-war-rule')
+    cy.wait('@getRuleDetailWithMedia')
+
+    cy.get('.screenshot-panel img').should('have.attr', 'src').and('include', '/static/rule-images/cover.png')
+    cy.get('.screenshot-single').should('have.attr', 'src').and('include', '/static/rule-images/shot.png')
+
+    cy.get('.upload-row input[type=file]').selectFile({
+      contents: Cypress.Buffer.from('image-bytes'),
+      fileName: 'review.png',
+      mimeType: 'image/png',
+    }, { force: true })
+    cy.contains('.upload-name', 'review.png').should('exist')
+    cy.get('.upload-preview').should('exist')
+
+    cy.get('.review-form textarea').type('带图评论')
+    cy.contains('button', '提交评论').click()
+
+    cy.wait('@uploadReviewImage')
+    cy.wait('@postReviewWithImage').its('request.body').should('deep.include', {
+      rating: 5,
+      content: '带图评论',
+      imageUrl: '/static/review-images/review-uploaded.png',
+    })
+    cy.contains('.review-item', '带图评论').should('be.visible')
   })
 
   it('详情页可以提交评论并跳转到快速用规则创建房间', () => {


### PR DESCRIPTION
## Summary
- add Cypress coverage for backend-hosted cover/screenshot rendering on rule detail
- verify the review-image upload call happens before the review submit request and its returned short URL is forwarded
- add browser-level coverage for the admin readonly visual preview route

## Related Issues
- Closes #174

## Verification
- `npm run test:unit`
- `CYPRESS_BASE_URL=http://127.0.0.1:4174 npx start-server-and-test "VITE_ENABLE_TEST_SANDBOX=true npm run build && vite preview --host 127.0.0.1 --port 4174 --strictPort" http://127.0.0.1:4174 "cypress run --browser electron"`

## Review
- `~/.codex/bin/claude-review --base main`
- Record: `/home/lih/.codex/cross-agent-review/Data-erhuo-.worktrees-WildCard_FrontEnd-test-latest-rule-market-flows/claude-code/20260614T035143Z-standard.json`